### PR TITLE
enable builds from the firmware directory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,7 +125,7 @@ jobs:
 #         cargo install --git https://github.com/japaric/flip-lld
 
 #     - name: Run examples
-#       working-directory: ./firmware/usbarmory
+#       working-directory: ./firmware
 #       run: |
 #         cargo run --example qemu-hello --release
 
@@ -181,12 +181,12 @@ jobs:
           cargo install --git https://github.com/japaric/flip-lld
 
       - name: Build examples using the dev profile
-        working-directory: ./firmware/usbarmory
+        working-directory: ./firmware
         run: |
           cargo build --examples
 
       - name: Build examples using the release profile
-        working-directory: ./firmware/usbarmory
+        working-directory: ./firmware
         run: |
           cargo build --examples --release
 

--- a/firmware/.cargo/config
+++ b/firmware/.cargo/config
@@ -1,3 +1,16 @@
+[target.armv7a-none-eabi]
+runner = "qemu-system-arm -cpu cortex-a7 -machine mcimx6ul-evk -nographic -semihosting-config enable=on,target=native -kernel"
+rustflags = [
+  "-C", "linker=flip-lld",
+  "-C", "link-arg=-Tlink.x",
+]
+
+[target.armv7a-none-eabihf]
+rustflags = [
+  "-C", "linker=flip-lld",
+  "-C", "link-arg=-Tlink.x",
+]
+
 [build]
 target = "armv7a-none-eabi" # soft float ABI, emulated float operations
 # target = "armv7a-none-eabihf" # hard float ABI, float operations on hardware

--- a/firmware/usbarmory/.cargo/config
+++ b/firmware/usbarmory/.cargo/config
@@ -1,15 +1,2 @@
-[target.armv7a-none-eabi]
-runner = "qemu-system-arm -cpu cortex-a7 -machine mcimx6ul-evk -nographic -semihosting-config enable=on,target=native -kernel"
-rustflags = [
-  "-C", "linker=flip-lld",
-  "-C", "link-arg=-Tlink.x",
-]
-
-[target.armv7a-none-eabihf]
-rustflags = [
-  "-C", "linker=flip-lld",
-  "-C", "link-arg=-Tlink.x",
-]
-
 [build]
 target = "armv7a-none-eabi"

--- a/firmware/usbarmory/README.md
+++ b/firmware/usbarmory/README.md
@@ -26,6 +26,9 @@ stage and will not be ready to use for some time.
 - [flip-lld], linker wrapper that adds zero-cost stack overflow protection.
   `cargo install --git https://github.com/japaric/flip-lld`.
 
+- `armv7a-none-eabi` compiler support. Install with `rustup target add
+  armv7a-none-eabi`.
+
 ## Development dependencies
 
 - `arm-none-eabi-binutils` OR (`cargo-binutils` + `llvm-tools-preview`), if you


### PR DESCRIPTION
and note that `rustup target add armv7a-none-eabi` is a required to build the firmware

addresses most of issue #17 