### PR TITLE
remove DWARF (`.debug_*`) sections from the ELF

### DIFF
--- a/firmware/usbarmory-rt/link.x
+++ b/firmware/usbarmory-rt/link.x
@@ -91,6 +91,11 @@ SECTIONS
   /* ## Discarded sections */
   /DISCARD/ :
   {
+    /* We are not using a debugger so we discard the DWARF sections
+       This makes the ELF file much smaller, which makes transfers over the
+       slow serial interface much faster */
+    *(.debug_*);
+
     /* Information required for unwinding that's used by Rust applications */
     *(.ARM.exidx);
     *(.ARM.exidx.*);


### PR DESCRIPTION
we are not using the debugger so the host does not make use these sections. This
reduces the size of ELF files by 33-88%, which makes transferring them over the
slow serial interface 3 to 8 times faster. As loading the program into the
target using u-boot requires copying the whole ELF into DDR RAM first, this
significantly improves interactive program loading times.

This change doesn't affect the amount of memory used by the program when it's
running.