### PR TITLE
Add Ferris logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,20 @@
 ![MSRV][msrv-image]
 [![Gitter Chat][gitter-image]][gitter-link]
 
+<img src="https://storage.googleapis.com/iqlusion-production-web/github/usbarmory/usbarmory-ferris.png" alt="USB armory mkII" width="384" height="384">
+
 Bare metal Rust development support for [USB armory MkII devices][usbarmory]
 from [F-Secure].
 
-<img src="https://storage.googleapis.com/iqlusion-production-web/github/usbarmory/usbarmory-mkII.png" alt="USB armory mkII" width="375" height="175">
+## Status
+
+Initial support for running bare metal Rust applications is now available.
+
+Check out the [`firmware/usbarmory`](firmware/usbarmory) directory.
 
 ## Minimum Supported Rust Version
 
 - Rust **1.42**
-
-## Status
-
-Check out the [`firmware/usbarmory`](firmware/usbarmory) directory.
 
 ## Contributing
 

--- a/firmware/usbarmory/src/lib.rs
+++ b/firmware/usbarmory/src/lib.rs
@@ -6,7 +6,10 @@
 //! - 'ULLRM': i.MX 6ULL Applications ProcessorReference Manual (IMX6ULLRM)
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/usbarmory/0.0.0")]
+#![doc(
+    html_logo_url = "https://storage.googleapis.com/iqlusion-production-web/github/usbarmory/usbarmory-ferris.png",
+    html_root_url = "https://docs.rs/usbarmory/0.0.0"
+)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 pub use cortex_a::delay;


### PR DESCRIPTION
![Ferris on USB armory](https://storage.googleapis.com/iqlusion-production-web/github/usbarmory/usbarmory-ferris.png)

USB armory mkII images used with permission. Original source:

https://inversepath.com/usbarmory.html#usbarmory_flat-tab