### PR TITLE
bump the flip-lld version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,7 +176,7 @@ jobs:
       # TODO cache in dev-dependencies.txt when available on crates.io
       - name: Install flip-lld
         run: |
-          cargo install --git https://github.com/japaric/flip-lld
+          cargo install --git https://github.com/japaric/flip-lld --rev 3130901af4ecc9cf7b2c4c8fc8c1090b70fa0cf1
 
       - name: Build examples using the dev profile
         working-directory: ./firmware

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,7 +176,7 @@ jobs:
       # TODO cache in dev-dependencies.txt when available on crates.io
       - name: Install flip-lld
         run: |
-          cargo install --git https://github.com/japaric/flip-lld --rev 3130901af4ecc9cf7b2c4c8fc8c1090b70fa0cf1
+          cargo install --git https://github.com/japaric/flip-lld --rev b1028b9b140150379ecdcea2c07580af933378e9
 
       - name: Build examples using the dev profile
         working-directory: ./firmware


### PR DESCRIPTION
the latest version includes a sanity check that verifies the ELF binary has a
valid memory layout and deletes it when it finds it to be invalid

this version also deals with (a) gaps between linker sections (which are created
by alignment requirements at the boundaries of linker sections) and (b) internal
gaps (which are caused by alignment requirements inside a section). These two
scenarios were creating invalid ELF binaries