### PR TITLE
DCP: expose HW accelerated SHA256

### DIFF
--- a/firmware/Cargo.lock
+++ b/firmware/Cargo.lock
@@ -106,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
 name = "exception-reset"
 version = "0.0.0"
 dependencies = [
@@ -291,6 +300,7 @@ dependencies = [
  "cortex-a",
  "cortex-a-rtfm",
  "cortex-m-semihosting",
+ "digest",
  "exception-reset",
  "heapless",
  "imx6ul-pac",

--- a/firmware/usbarmory/Cargo.toml
+++ b/firmware/usbarmory/Cargo.toml
@@ -16,6 +16,7 @@ arrayref = "0.3.6"
 block-cipher-trait = "0.6.2"
 consts = { path = "../../common/consts" }
 cortex-a = { path = "../cortex-a" }
+digest = "0.8.1"
 heapless = "0.5.3"
 memlog = { path = "../memlog" }
 pac = { package = "imx6ul-pac", path = "../imx6ul-pac" }

--- a/firmware/usbarmory/examples/aes-otp.rs
+++ b/firmware/usbarmory/examples/aes-otp.rs
@@ -14,7 +14,7 @@ use usbarmory::{dcp::Aes128, memlog, memlog_flush_and_reset};
 // like `#[rtfm::app]`
 #[no_mangle]
 fn main() -> ! {
-    let cipher = Aes128::new_otp();
+    let cipher = Aes128::new_otp().expect("AES engine already in use");
 
     let plaintext = [
         179, 176, 19, 230, 198, 237, 169, 162, 83, 237, 103, 21, 175, 240, 64, 242,

--- a/firmware/usbarmory/examples/aes-unique.rs
+++ b/firmware/usbarmory/examples/aes-unique.rs
@@ -26,7 +26,7 @@ use usbarmory::{dcp::Aes128, memlog, memlog_flush_and_reset};
 // like `#[rtfm::app]`
 #[no_mangle]
 fn main() -> ! {
-    let cipher = Aes128::new_unique();
+    let cipher = Aes128::new_unique().expect("AES engine already in use");
 
     let plaintext = [
         179, 176, 19, 230, 198, 237, 169, 162, 83, 237, 103, 21, 175, 240, 64, 242,

--- a/firmware/usbarmory/examples/sha256.rs
+++ b/firmware/usbarmory/examples/sha256.rs
@@ -1,0 +1,159 @@
+//! Test our `Sha256` implementation against the `sha2` implementation
+
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use digest::{FixedOutput, Input, Reset};
+use exception_reset as _; // default exception handler
+use panic_serial as _; // panic handler
+use usbarmory::{dcp::Sha256, memlog, memlog_flush_and_reset};
+
+// The `expected` values come from running the following code on a x86_64 machine
+//
+// ``` rust
+// use sha2::{Digest, Sha256};
+// let input: &[u8] = /* .. */;
+// let mut hasher = Sha256::new();
+// hasher.input(input);
+// let expected = hasher.result();
+// ```
+static TESTS: &[(/*input: */ &[u8], /* expected: */ [u8; 32])] = &[
+    // 1 block
+    (
+        &[0; 64],
+        [
+            245, 165, 253, 66, 209, 106, 32, 48, 39, 152, 239, 110, 211, 9, 151, 155, 67, 0, 61,
+            35, 32, 217, 240, 232, 234, 152, 49, 169, 39, 89, 251, 75,
+        ],
+    ),
+    (
+        &[
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45,
+            46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+        ],
+        [
+            253, 234, 185, 172, 243, 113, 3, 98, 189, 38, 88, 205, 201, 162, 158, 143, 156, 117,
+            127, 207, 152, 17, 96, 58, 140, 68, 124, 209, 217, 21, 17, 8,
+        ],
+    ),
+    // 2 blocks
+    (
+        &[0; 128],
+        [
+            56, 114, 58, 46, 94, 138, 23, 170, 121, 80, 220, 0, 130, 9, 148, 78, 137, 143, 105,
+            167, 189, 16, 162, 60, 131, 157, 52, 30, 147, 95, 213, 202,
+        ],
+    ),
+    // partial block
+    (
+        &[0; 31],
+        [
+            253, 8, 190, 149, 123, 218, 7, 220, 82, 154, 216, 16, 13, 247, 50, 249, 206, 18, 174,
+            62, 66, 188, 218, 106, 202, 190, 18, 192, 45, 253, 105, 137,
+        ],
+    ),
+    (
+        &[0; 63],
+        [
+            199, 114, 63, 161, 224, 18, 121, 117, 228, 158, 98, 231, 83, 219, 83, 146, 76, 27, 216,
+            75, 138, 193, 172, 8, 223, 120, 208, 146, 112, 243, 217, 113,
+        ],
+    ),
+];
+
+// the input will be fed in chunks to the hasher -- the following chunk sizes will be used
+const CHUNK_SIZES: &[usize] = &[128, 64, 32, 16, 11, 7, 5];
+
+// NOTE binary interfaces, using `no_mangle` and `extern`, are extremely unsafe
+// as no type checking is performed by the compiler; stick to safe interfaces
+// like `#[rtfm::app]`
+#[no_mangle]
+fn main() -> ! {
+    for (input, expected) in TESTS {
+        if input.iter().all(|b| *b == 0) {
+            memlog!("input:    {} zeros", input.len());
+            usbarmory::memlog_try_flush();
+        } else {
+            memlog!("input:    {:?}", &input[..]);
+            usbarmory::memlog_try_flush();
+        }
+
+        let mut first_hash = true;
+        for chunk_size in CHUNK_SIZES {
+            let mut hasher = Sha256::take().expect("taken");
+            for chunk in input.chunks(*chunk_size) {
+                hasher.input(chunk);
+            }
+            let output = hasher.fixed_result();
+
+            if first_hash {
+                memlog!("output:   {:?}", output);
+                memlog!("expected: {:?}", expected);
+                usbarmory::memlog_try_flush();
+                first_hash = false;
+            }
+
+            if output[..] != expected[..] {
+                memlog!("error: incorrect result with chunk_size={}", chunk_size);
+                memlog_flush_and_reset!()
+            }
+
+            // test the `reset` API
+            // hash
+            let mut hasher = Sha256::take().expect("taken");
+            for chunk in input.chunks(*chunk_size) {
+                hasher.input(chunk);
+            }
+            // abort before result
+            hasher.reset();
+
+            // hash for real this time
+            for chunk in input.chunks(*chunk_size) {
+                hasher.input(chunk);
+            }
+            let output = hasher.fixed_result();
+
+            if output[..] != expected[..] {
+                memlog!(
+                    "error: incorrect result with chunk_size={} & reset at the end",
+                    chunk_size
+                );
+                memlog_flush_and_reset!()
+            }
+
+            // hash and immediately abort
+            let mut hasher = Sha256::take().expect("taken");
+            for chunk in input.chunks(*chunk_size) {
+                hasher.input(chunk);
+                hasher.reset();
+                break;
+            }
+
+            // hash for real this time
+            for chunk in input.chunks(*chunk_size) {
+                hasher.input(chunk);
+            }
+            let output = hasher.fixed_result();
+
+            if output[..] != expected[..] {
+                memlog!(
+                    "error: incorrect result with chunk_size={} & reset at the beginning",
+                    chunk_size
+                );
+                memlog_flush_and_reset!()
+            }
+        }
+
+        memlog!("OK");
+
+        // flush a bit so the memlog buffer doesn't completely fill
+        for _ in 0..100_000 {
+            usbarmory::memlog_try_flush();
+        }
+    }
+
+    memlog!("DONE");
+    memlog_flush_and_reset!()
+}

--- a/firmware/usbarmory/src/dcp/aes128.rs
+++ b/firmware/usbarmory/src/dcp/aes128.rs
@@ -1,0 +1,215 @@
+use core::{
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::atomic::{self, AtomicBool, Ordering},
+};
+
+use arrayref::array_ref;
+use block_cipher_trait::{
+    generic_array::{typenum::consts, GenericArray},
+    BlockCipher,
+};
+use pac::hw_dcp::HW_DCP;
+
+use crate::{
+    dcp::{
+        self, CipherMode, CipherSelect, Cmd, Control0, Control1, KeySelect, AES128_CHANNEL,
+        STAT_ERROR_MASK,
+    },
+    memlog, memlog_flush_and_reset, util,
+};
+
+/// AES-128 channel
+pub struct Aes128 {
+    key: KeySelect,
+    // this struct implicitly owns a shared reference to `HW_DCP` ..
+    _not_send_or_sync: PhantomData<*mut ()>,
+}
+
+// .. however it accesses different registers so instances are OK to `Send`
+unsafe impl Send for Aes128 {}
+
+impl Drop for Aes128 {
+    fn drop(&mut self) {
+        AES_IN_USE.store(false, Ordering::Release)
+    }
+}
+
+impl BlockCipher for Aes128 {
+    type KeySize = consts::U16;
+    type BlockSize = consts::U16;
+    type ParBlocks = consts::U1;
+
+    fn new(key: &GenericArray<u8, consts::U16>) -> Self {
+        Self::new_ram(key).expect("the `Aes128` is currently in use")
+    }
+
+    fn decrypt_block(&self, block: &mut GenericArray<u8, consts::U16>) {
+        self.xcrypt(block, false)
+    }
+
+    fn encrypt_block(&self, block: &mut GenericArray<u8, consts::U16>) {
+        self.xcrypt(block, true)
+    }
+}
+
+static AES_IN_USE: AtomicBool = AtomicBool::new(false);
+
+impl Aes128 {
+    /// Gets a handle to the AES-128 channel and configures it to use the unreadable OTP key
+    ///
+    /// This function returns `None` if the channel is currently in use
+    ///
+    /// **WARNING!** This routine does NOT check if the OTP was set to an all-zeros value
+    pub fn new_otp() -> Option<Self> {
+        Self::new_hardware(true)
+    }
+
+    /// Gets a handle to the AES-128 channel and configures it to use the unreadable UNIQUE key
+    ///
+    /// This function returns `None` if the channel is currently in use
+    ///
+    /// This UNIQUE key is generated from the OTP key and a device-specific 64-bit value
+    pub fn new_unique() -> Option<Self> {
+        Self::new_hardware(false)
+    }
+
+    // Creates a cipher that uses one of the two available hardware keys
+    fn new_hardware(otp: bool) -> Option<Self> {
+        if AES_IN_USE
+            .compare_exchange_weak(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            dcp::init();
+
+            HW_DCP::borrow_unchecked(|dcp| {
+                const STAT_OTP_KEY_READY: u32 = 1 << 28;
+
+                // check that the OTP is ready to use ("has been released")
+                let mut stat = 0;
+                let is_ready = || {
+                    stat = dcp.STAT.read();
+                    stat & STAT_OTP_KEY_READY != 0
+                };
+                if util::wait_for_or_timeout(is_ready, dcp::default_timeout()).is_err() {
+                    memlog!("OTP key not released within timeout (STAT={:#010x})", stat);
+                    memlog_flush_and_reset!()
+                }
+
+                // enable channel #3
+                // NOTE single instruction write to a stateless register
+                dcp.CHANNELCTRL_SET.write(1 << AES128_CHANNEL);
+            });
+
+            Some(Aes128 {
+                key: if otp {
+                    KeySelect::OtpKey
+                } else {
+                    KeySelect::UniqueKey
+                },
+                _not_send_or_sync: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn new_ram(key: &GenericArray<u8, consts::U16>) -> Option<Self> {
+        if AES_IN_USE
+            .compare_exchange_weak(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            dcp::init();
+
+            HW_DCP::borrow_unchecked(|dcp| {
+                // install key in the write-only register
+                // NOTE to support multiple cipher instances this would need a mutex (e.g. spinlock)
+                // to do a exclusive write to these registers
+                dcp.KEY.write(u32::from(AES128_CHANNEL) << 6);
+                // XXX double check endianness
+                dcp.KEYDATA
+                    .write(u32::from_le_bytes(*array_ref!(key, 0, 4)));
+                dcp.KEYDATA
+                    .write(u32::from_le_bytes(*array_ref!(key, 4, 4)));
+                dcp.KEYDATA
+                    .write(u32::from_le_bytes(*array_ref!(key, 8, 4)));
+                dcp.KEYDATA
+                    .write(u32::from_le_bytes(*array_ref!(key, 12, 4)));
+
+                // enable channel #3
+                // NOTE single instruction write to a stateless register
+                dcp.CHANNELCTRL_SET.write(1 << AES128_CHANNEL);
+            });
+
+            Some(Aes128 {
+                key: KeySelect::Key0,
+                _not_send_or_sync: PhantomData,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn xcrypt(&self, block: &mut GenericArray<u8, consts::U16>, encrypt: bool) {
+        let cmd = Cmd::new();
+
+        cmd.control0.set(
+            *Control0::new()
+                .decr_semaphore(true)
+                .enable_cipher(true)
+                .cipher_encrypt(encrypt)
+                .otp_key(self.key == KeySelect::OtpKey),
+        );
+
+        cmd.control1.set(
+            *Control1::new()
+                .cipher_select(CipherSelect::Aes128)
+                .cipher_mode(CipherMode::Ecb)
+                .key_select(self.key),
+        );
+
+        cmd.src_buffer_addr.set(Some(NonNull::from(&block[0])));
+        cmd.dest_buffer_addr.set(Some(NonNull::from(&mut block[0])));
+        cmd.buffer_size.set(block.len());
+
+        HW_DCP::borrow_unchecked(|dcp| {
+            // TODO generalize over channel index
+            dcp.CH3CMDPTR.write(&cmd as *const Cmd as u32);
+
+            // the write below transfers ownership of `block` and `cmd` to the crypto engine; this
+            // fence drives all pending writes to `block` & `cmd` to completion
+            atomic::fence(Ordering::Release);
+
+            // start encryption
+            dcp.CH3SEMA.write(1);
+
+            // wait for channel to signal it's done -- the trait interface requires this operation
+            // to be blocking
+            let mut stat = 0;
+            let mut status = 0;
+            let is_done_or_error = || {
+                // NOTE(read_volatile) we want this statement to always perform a load
+                // instruction rather than read memory once and cache the value in a (CPU)
+                // register
+                status = unsafe { cmd.status.get().read_volatile() };
+                stat = dcp.CH3STAT.read();
+
+                // done or error
+                status & 1 != 0 || stat & STAT_ERROR_MASK != 0
+            };
+            if util::wait_for_or_timeout(is_done_or_error, dcp::default_timeout()).is_err() {
+                memlog!("encryption timeout (STAT={:#010x})", stat);
+                memlog_flush_and_reset!()
+            }
+
+            // the crypto engine is done with the block and has transferred ownership back to us
+            atomic::fence(Ordering::Acquire);
+
+            // the interface won't let us report the error so just abort the program
+            if stat & STAT_ERROR_MASK != 0 {
+                memlog!("error (STAT={:#010x}, Cmd.status={:#010x})", stat, status);
+                memlog_flush_and_reset!()
+            }
+        })
+    }
+}

--- a/firmware/usbarmory/src/dcp/sha256.rs
+++ b/firmware/usbarmory/src/dcp/sha256.rs
@@ -1,0 +1,306 @@
+use core::{
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::atomic::{self, AtomicBool, Ordering},
+};
+
+use block_cipher_trait::generic_array::{typenum::consts, GenericArray};
+use digest::{BlockInput, FixedOutput, Input, Reset};
+use heapless::Vec;
+use pac::hw_dcp::HW_DCP;
+use typenum::marker_traits::Unsigned;
+
+use crate::{
+    dcp::{self, Cmd, Control0, Control1, HashSelect, SHA256_CHANNEL, STAT_ERROR_MASK},
+    memlog, memlog_flush_and_reset,
+    util::{self, Align4},
+};
+
+// The DCP has a 32 *bit* counter and won't accept more than 512 MB of input
+const MAX_COUNT: usize = 512 * 1024 * 1024;
+
+type BlockSize = consts::U64;
+
+/// SHA-256 channel
+pub struct Sha256 {
+    _not_send_or_sync: PhantomData<*const ()>,
+    next_is_first_block: bool,
+    // We collect partial blocks until we have a complete block
+    buffer: Vec<u8, BlockSize>,
+    /// Input counter, in *bytes*
+    count: usize,
+}
+
+unsafe impl Send for Sha256 {}
+
+static SHA_IN_USE: AtomicBool = AtomicBool::new(false);
+
+impl Sha256 {
+    /// Gets a handle to the SHA-256 channel
+    ///
+    /// This function returns `None` if the channel is currently in use
+    pub fn take() -> Option<Self> {
+        if SHA_IN_USE
+            .compare_exchange_weak(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            dcp::init();
+
+            // NOTE(borrow_unchecked) single-instruction write to a stateless register
+            HW_DCP::borrow_unchecked(|dcp| {
+                dcp.CHANNELCTRL_SET.write(1 << SHA256_CHANNEL);
+            });
+
+            Some(Sha256 {
+                _not_send_or_sync: PhantomData,
+                buffer: Vec::new(),
+                count: 0,
+                next_is_first_block: true,
+            })
+        } else {
+            None
+        }
+    }
+
+    // non-generic version of `Input::input` to reduce .text size (monomorphizations on `Input`
+    // become jumps into this common function)
+    fn input_slice(&mut self, input: &[u8]) {
+        if input.is_empty() {
+            // no-op
+            return;
+        }
+
+        if self
+            .count
+            .checked_add(input.len())
+            .map(|total| total > MAX_COUNT)
+            .unwrap_or(true)
+        {
+            panic!("Sha256: total input exceeds the DCP capacity");
+        }
+
+        self.count += input.len();
+
+        if self.buffer.is_empty() {
+            // process leading blocks then store the leftover
+            process_and_push(&mut self.next_is_first_block, &mut self.buffer, input);
+        } else if self.buffer.len() + input.len() < BlockSize::USIZE {
+            // not enough to fill a block
+            let _ = self.buffer.extend_from_slice(input);
+        } else {
+            // complete the partial block and then process the rest
+            push_and_process(&mut self.next_is_first_block, &mut self.buffer, input)
+        }
+    }
+}
+
+fn process_and_push(next_is_first_block: &mut bool, buffer: &mut Vec<u8, BlockSize>, input: &[u8]) {
+    debug_assert!(buffer.is_empty());
+
+    let leftover = if input.len() >= BlockSize::USIZE {
+        let (blocks, leftover) = input.split_at(util::round_down(input.len(), BlockSize::USIZE));
+
+        process_blocks(next_is_first_block, blocks);
+        leftover
+    } else {
+        input
+    };
+
+    let _ = buffer.extend_from_slice(leftover);
+}
+
+fn push_and_process(next_is_first_block: &mut bool, buffer: &mut Vec<u8, BlockSize>, input: &[u8]) {
+    debug_assert!(!buffer.is_empty());
+
+    let (head, tail) = input.split_at(BlockSize::USIZE - buffer.len());
+
+    // complete a block
+    let _ = buffer.extend_from_slice(head);
+    process_blocks(next_is_first_block, buffer);
+    buffer.clear();
+
+    process_and_push(next_is_first_block, buffer, tail)
+}
+
+// NOTE only the last block (`hash_term = true`) can be smaller than 512 bits
+fn process_blocks(next_is_first_block: &mut bool, blocks: &[u8]) {
+    debug_assert!(!blocks.is_empty());
+    debug_assert_eq!(blocks.len() % BlockSize::USIZE, 0);
+
+    let cmd = Cmd::new();
+
+    cmd.control0.set(
+        *Control0::new()
+            .decr_semaphore(true)
+            .enable_hash(true)
+            .hash_output(false) // hash input data
+            .hash_init(*next_is_first_block)
+            .hash_term(false),
+    );
+    *next_is_first_block = false;
+
+    cmd.control1
+        .set(*Control1::new().hash_select(HashSelect::Sha256));
+
+    cmd.src_buffer_addr.set(Some(NonNull::from(&blocks[0])));
+    // redundant: `Cmd::new` sets `dest_buffer_addr` to `None`
+    // cmd.dest_buffer_addr.set(None);
+    cmd.buffer_size.set(blocks.len());
+
+    HW_DCP::borrow_unchecked(|dcp| {
+        // TODO generalize over channel index
+        dcp.CH2CMDPTR.write(&cmd as *const Cmd as u32);
+
+        // the write below transfers ownership of `bytes` to the crypto engine; this fence
+        // drives all pending writes to `bytes` to completion
+        atomic::fence(Ordering::Release);
+
+        // start encryption
+        dcp.CH2SEMA.write(1);
+
+        // wait for channel to signal it's done -- the trait interface requires this operation
+        // to be blocking
+        let mut stat = 0;
+        let mut status = 0;
+        let is_done_or_error = || {
+            // NOTE(read_volatile) we want this statement to always perform a load
+            // instruction rather than read memory once and cache the value in a (CPU)
+            // register
+            status = unsafe { cmd.status.get().read_volatile() };
+            stat = dcp.CH2STAT.read();
+
+            // done or error
+            status & 1 != 0 || stat & STAT_ERROR_MASK != 0
+        };
+        if util::wait_for_or_timeout(is_done_or_error, dcp::default_timeout()).is_err() {
+            memlog!("digest timeout (STAT={:#010x})", stat);
+            memlog_flush_and_reset!()
+        }
+
+        // the crypto engine is done with the `bytes` and has transferred ownership back to us
+        atomic::fence(Ordering::Acquire);
+
+        // the interface won't let us report the error so just abort the program
+        if stat & STAT_ERROR_MASK != 0 {
+            memlog!(
+                "digest error (STAT={:#010x}, Cmd.status={:#010x})",
+                stat,
+                status
+            );
+            memlog_flush_and_reset!()
+        }
+    })
+}
+
+impl Input for Sha256 {
+    fn input<B>(&mut self, bytes: B)
+    where
+        B: AsRef<[u8]>,
+    {
+        self.input_slice(bytes.as_ref());
+    }
+}
+
+impl FixedOutput for Sha256 {
+    type OutputSize = consts::U32;
+
+    fn fixed_result(self) -> GenericArray<u8, consts::U32> {
+        // word aligned for performance
+        let mut output = Align4 {
+            inner: GenericArray::from([0; 32]),
+        };
+
+        let cmd = Cmd::new();
+
+        cmd.control0.set(
+            *Control0::new()
+                .decr_semaphore(true)
+                .enable_hash(true)
+                .hash_output(false) // hash input data
+                .hash_init(self.next_is_first_block)
+                .hash_term(true),
+        );
+
+        cmd.control1
+            .set(*Control1::new().hash_select(HashSelect::Sha256));
+
+        if !self.buffer.is_empty() {
+            cmd.src_buffer_addr
+                .set(Some(NonNull::from(&self.buffer[0])));
+            cmd.buffer_size.set(self.buffer.len());
+        }
+
+        cmd.payload_pointer
+            .set(Some(NonNull::from(&mut output.inner[0])));
+
+        HW_DCP::borrow_unchecked(|dcp| {
+            // TODO generalize over channel index
+            dcp.CH2CMDPTR.write(&cmd as *const Cmd as u32);
+
+            // the write below transfers ownership of `output` to the crypto engine; this fence
+            // drives all pending writes to `output` to completion
+            atomic::fence(Ordering::Release);
+
+            // start encryption
+            dcp.CH2SEMA.write(1);
+
+            // wait for channel to signal it's done -- the trait interface requires this operation
+            // to be blocking
+            let mut stat = 0;
+            let mut status = 0;
+            let is_done_or_error = || {
+                // NOTE(read_volatile) we want this statement to always perform a load
+                // instruction rather than read memory once and cache the value in a (CPU)
+                // register
+                status = unsafe { cmd.status.get().read_volatile() };
+                stat = dcp.CH2STAT.read();
+
+                // done or error
+                status & 1 != 0 || stat & STAT_ERROR_MASK != 0
+            };
+            if util::wait_for_or_timeout(is_done_or_error, dcp::default_timeout()).is_err() {
+                memlog!("digest timeout (STAT={:#010x})", stat);
+                memlog_flush_and_reset!()
+            }
+
+            // the crypto engine is done with `output` and has transferred ownership back to us
+            atomic::fence(Ordering::Acquire);
+
+            // the interface won't let us report the error so just abort the program
+            if stat & STAT_ERROR_MASK != 0 {
+                memlog!(
+                    "digest error (STAT={:#010x}, Cmd.status={:#010x})",
+                    stat,
+                    status
+                );
+                memlog_flush_and_reset!()
+            }
+        });
+
+        // the engine returns data in reverse order (big endian?)
+        output.inner.reverse();
+        output.inner
+    }
+}
+
+impl Reset for Sha256 {
+    fn reset(&mut self) {
+        self.buffer.clear();
+        self.next_is_first_block = true;
+    }
+}
+
+impl BlockInput for Sha256 {
+    type BlockSize = consts::U64;
+}
+
+impl Drop for Sha256 {
+    fn drop(&mut self) {
+        // NOTE(borrow_unchecked) single-instruction write to a stateless register
+        HW_DCP::borrow_unchecked(|dcp| {
+            dcp.CHANNELCTRL_CLR.write(1 << SHA256_CHANNEL);
+        });
+
+        SHA_IN_USE.store(false, Ordering::Release);
+    }
+}

--- a/firmware/usbarmory/src/util.rs
+++ b/firmware/usbarmory/src/util.rs
@@ -17,3 +17,12 @@ pub fn wait_for_or_timeout(mut cond: impl FnMut() -> bool, timeout: Duration) ->
     }
     Ok(())
 }
+
+#[repr(align(4))]
+pub struct Align4<T> {
+    pub inner: T,
+}
+
+pub fn round_down(n: usize, m: usize) -> usize {
+    n - (n % m)
+}


### PR DESCRIPTION
this commit also partially lifts the single `Aes` instance restriction. You can
now call `Aes::new` more than once but you cannot have more than one *live*
instance at any point in time.

``` rust
let aes1 = Aes::new(key);
let aes2 = Aes::new(key);
//^ this panics

let aes1 = Aes::new(key);
drop(aes1);
let aes2 = Aes::new(key);
//^ this is OK
```

The new `Sha256` abstraction has the same restriction in its `new` constructor

In the future we'll support creating up to 4 concurrent DCP instances, in any
combination of `Aes128` and `Sha256` instances.

Also, [breaking-change], the return type of `Aes128::new_otp` and
`Aes128::new_unique` is now `Option<Self>` instead of `Self`; the constructor
will no longer internally panic when another instance of `Aes128` already exists
but rather return `None`.

This should close #40 