### PR TITLE
usbarmory-rt: add Cargo feature to move .text and .rodata to DDR RAM

### DIFF
--- a/firmware/usbarmory-rt/Cargo.toml
+++ b/firmware/usbarmory-rt/Cargo.toml
@@ -9,5 +9,9 @@ license = "Apache-2.0 OR MIT"
 cortex-a = { path = "../cortex-a" }
 pac = { package = "imx6ul-pac", path = "../imx6ul-pac" }
 
+[features]
+# enable this feature to place .text and .rodata in DDR3 RAM
+use-dram = []
+
 [build-dependencies]
 quote = "1.0.2"

--- a/firmware/usbarmory-rt/build.rs
+++ b/firmware/usbarmory-rt/build.rs
@@ -15,7 +15,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     txt2rust(&out_dir)?;
 
     // place the linker script somewhere the linker can find it
-    fs::write(out_dir.join("link.x"), fs::read("link.x")?)?;
+
+    let link_x = if env::var("CARGO_FEATURE_USE_DRAM").is_ok() {
+        fs::read("link-dram.x")?
+    } else {
+        fs::read("link-ocram.x")?
+    };
+    fs::write(out_dir.join("link.x"), link_x)?;
 
     // place the assembly part of the entry point somewhere the linker can find it
     fs::copy(

--- a/firmware/usbarmory-rt/link-dram.x
+++ b/firmware/usbarmory-rt/link-dram.x
@@ -1,0 +1,114 @@
+/* Entry point of the ELF image */
+ENTRY(_start);
+
+/* # Memory regions */
+MEMORY
+{
+  /* On-chip RAM */
+  OCRAM : ORIGIN = 0x00900000, LENGTH = 128K
+
+  /* Secure RAM */
+  CAAM : ORIGIN = 0x00100000, LENGTH = 32K
+
+  /* DDR3 RAM */
+  /* NOTE
+     - DRAM starts at address 0x8000_0000 and has a size of 512MB
+     - the boot ROM will load u-boot into OCRAM, but
+     - u-boot will relocate itself at the end of DRAM (0xA000_0000); occupying
+       the space between `relocaddr` (see the output of the `bdinfo` command)
+       and the end of DRAM. In my case, `relocaddr` has a value of `0x9ff7a000`
+       so u-boot is using 536 KB of DRAM.
+     - u-boot loads ELFs at address 0x8200_0000; ELFs are usually <1MB in size
+     - given all this we'll limit our use of DRAM use to the range 0x8000_0000 -
+       0x8200_0000; that is before the ELF staging space.
+  */
+  DRAM : ORIGIN = 0x80000000, LENGTH = 32M
+}
+
+/* Use the default exception handler to handle all exceptions that have not been set by the user */
+PROVIDE(UndefinedInstruction = DefaultHandler);
+PROVIDE(SupervisorCall = DefaultHandler);
+PROVIDE(PrefetchAbort = DefaultHandler);
+PROVIDE(DataAbort = DefaultHandler);
+PROVIDE(HypervisorCall = DefaultHandler);
+PROVIDE(IRQ = DefaultHandler);
+PROVIDE(FIQ = DefaultHandler);
+
+/* Same thing with unset interrupts */
+PROVIDE(SGI0 = DefaultHandler);
+PROVIDE(SGI1 = DefaultHandler);
+PROVIDE(SGI2 = DefaultHandler);
+PROVIDE(SGI3 = DefaultHandler);
+PROVIDE(SGI4 = DefaultHandler);
+PROVIDE(SGI5 = DefaultHandler);
+PROVIDE(SGI6 = DefaultHandler);
+PROVIDE(SGI7 = DefaultHandler);
+PROVIDE(SGI8 = DefaultHandler);
+PROVIDE(SGI9 = DefaultHandler);
+PROVIDE(SGI10 = DefaultHandler);
+PROVIDE(SGI11 = DefaultHandler);
+PROVIDE(SGI12 = DefaultHandler);
+PROVIDE(SGI13 = DefaultHandler);
+PROVIDE(SGI14 = DefaultHandler);
+PROVIDE(SGI15 = DefaultHandler);
+
+INCLUDE interrupts.x
+
+/* Make the linker exhaustively search these symbols, otherwise they may be ignored even if provided */
+EXTERN(_exceptions);
+
+/* Top of the stack */
+PROVIDE(__stack_top__ = ORIGIN(OCRAM) + LENGTH(OCRAM));
+
+/* Where to place things that are not the stack in RAM */
+PROVIDE(__ram_start__ = ORIGIN(OCRAM));
+
+/* # Linker sections */
+SECTIONS
+{
+  /* ## Standard ELF sections */
+  .text :
+  {
+    /* put the entry point first to make the objdump easier to read */
+    *(.text._start);
+    *(.text.start);
+
+    /* the exception vector has an alignment requirement */
+    . = ALIGN(32);
+    KEEP(*(.text._exceptions));
+
+    *(.text .text.*);
+  } > DRAM
+
+  .rodata :
+  {
+    *(.rodata .rodata.*);
+  } > DRAM
+
+  .data __ram_start__ :
+  {
+    *(.data .data.*);
+  } > OCRAM
+
+  .bss ADDR(.data) + SIZEOF(.data) :
+  {
+    *(.bss .bss.*);
+  } > OCRAM
+
+  /* ## Discarded sections */
+  /DISCARD/ :
+  {
+    /* We are not using a debugger so we discard the DWARF sections
+       This makes the ELF file much smaller, which makes transfers over the
+       slow serial interface much faster */
+    *(.debug_*);
+
+    /* Information required for unwinding that's used by Rust applications */
+    *(.ARM.exidx);
+    *(.ARM.exidx.*);
+    *(.ARM.extab.*);
+  }
+}
+
+/* alignment requirement */
+ASSERT(_exceptions % 32 == 0, "exception vector is not 32-byte aligned");

--- a/firmware/usbarmory-rt/link-ocram.x
+++ b/firmware/usbarmory-rt/link-ocram.x
@@ -15,7 +15,18 @@ MEMORY
   CAAM : ORIGIN = 0x00100000, LENGTH = 32K
 
   /* DDR3 RAM */
-  DRAM : ORIGIN = 0x80000000, LENGTH = 512M
+  /* NOTE
+     - DRAM starts at address 0x8000_0000 and has a size of 512MB
+     - the boot ROM will load u-boot into OCRAM, but
+     - u-boot will relocate itself at the end of DRAM (0xA000_0000); occupying
+       the space between `relocaddr` (see the output of the `bdinfo` command)
+       and the end of DRAM. In my case, `relocaddr` has a value of `0x9ff7a000`
+       so u-boot is using 536 KB of DRAM.
+     - u-boot loads ELFs at address 0x8200_0000; ELFs are usually <1MB in size
+     - given all this we'll limit our use of DRAM use to the range 0x8000_0000 -
+       0x8200_0000; that is before the ELF staging space.
+  */
+  DRAM : ORIGIN = 0x80000000, LENGTH = 32M
 }
 
 /* Use the default exception handler to handle all exceptions that have not been set by the user */

--- a/firmware/usbarmory/Cargo.toml
+++ b/firmware/usbarmory/Cargo.toml
@@ -22,7 +22,11 @@ pac = { package = "imx6ul-pac", path = "../imx6ul-pac" }
 rand_core = "0.5.1"
 typenum = "1.11.2"
 usb-device = "0.2.5"
-usbarmory-rt = { path = "../usbarmory-rt" }
+
+[dependencies.usbarmory-rt]
+path = "../usbarmory-rt"
+## enable this feature to place .text and .rodata in DRAM
+# features = ["use-dram"]
 
 [dev-dependencies]
 as-slice = "0.1.3"


### PR DESCRIPTION
the default is to place all linker sections: instructions (`.text`),
constants (`.rodata`), data (`.bss` / `.data`) and stack in On-Chip RAM (OCRAM,
128 KB)

when this Cargo feature is enabled the instructions and the constants will be
placed in DDR RAM, which has a capacity of 512 MB

the use of DDR RAM is currently capped at 32 MB to avoid .text and .rodata being
loaded into the staging area that u-boot uses to hold ELF files

closes #45 
note that this doesn't address #31