### PR TITLE
eMMC refactor

### DIFF
--- a/firmware/imx6ul-pac/src/lib.rs
+++ b/firmware/imx6ul-pac/src/lib.rs
@@ -157,6 +157,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog ARM PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -182,6 +187,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog ARM PLL control Register"]
@@ -209,6 +219,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog ARM PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -234,6 +249,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog USB1 480MHz PLL Control Register"]
@@ -261,6 +281,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog USB1 480MHz PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -286,6 +311,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog USB1 480MHz PLL Control Register"]
@@ -313,6 +343,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog USB1 480MHz PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -338,6 +373,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog USB2 480MHz PLL Control Register"]
@@ -365,6 +405,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog USB2 480MHz PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -390,6 +435,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog USB2 480MHz PLL Control Register"]
@@ -417,6 +467,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog USB2 480MHz PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -442,6 +497,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog System PLL Control Register"]
@@ -469,6 +529,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog System PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -494,6 +559,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog System PLL Control Register"]
@@ -521,6 +591,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog System PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -546,6 +621,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "528MHz System PLL Spread Spectrum Register"]
@@ -573,6 +653,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Numerator of 528MHz System PLL Fractional Loop Divider Register"]
     #[allow(non_camel_case_types)]
@@ -598,6 +683,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Denominator of 528MHz System PLL Fractional Loop Divider Register"]
@@ -625,6 +715,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog Audio PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -650,6 +745,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog Audio PLL control Register"]
@@ -677,6 +777,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog Audio PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -702,6 +807,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog Audio PLL control Register"]
@@ -729,6 +839,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Numerator of Audio PLL Fractional Loop Divider Register"]
     #[allow(non_camel_case_types)]
@@ -754,6 +869,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Denominator of Audio PLL Fractional Loop Divider Register"]
@@ -781,6 +901,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog Video PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -806,6 +931,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog Video PLL control Register"]
@@ -833,6 +963,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog Video PLL control Register"]
     #[allow(non_camel_case_types)]
@@ -858,6 +993,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog Video PLL control Register"]
@@ -885,6 +1025,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Numerator of Video PLL Fractional Loop Divider Register"]
     #[allow(non_camel_case_types)]
@@ -910,6 +1055,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Denominator of Video PLL Fractional Loop Divider Register"]
@@ -937,6 +1087,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog ENET PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -962,6 +1117,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog ENET PLL Control Register"]
@@ -989,6 +1149,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Analog ENET PLL Control Register"]
     #[allow(non_camel_case_types)]
@@ -1014,6 +1179,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Analog ENET PLL Control Register"]
@@ -1041,6 +1211,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "480MHz Clock (PLL3) Phase Fractional Divider Control Register"]
     #[allow(non_camel_case_types)]
@@ -1066,6 +1241,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "480MHz Clock (PLL3) Phase Fractional Divider Control Register"]
@@ -1093,6 +1273,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "480MHz Clock (PLL3) Phase Fractional Divider Control Register"]
     #[allow(non_camel_case_types)]
@@ -1118,6 +1303,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "480MHz Clock (PLL3) Phase Fractional Divider Control Register"]
@@ -1145,6 +1335,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "528MHz Clock (PLL2) Phase Fractional Divider Control Register"]
     #[allow(non_camel_case_types)]
@@ -1170,6 +1365,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "528MHz Clock (PLL2) Phase Fractional Divider Control Register"]
@@ -1197,6 +1397,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "528MHz Clock (PLL2) Phase Fractional Divider Control Register"]
     #[allow(non_camel_case_types)]
@@ -1222,6 +1427,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "528MHz Clock (PLL2) Phase Fractional Divider Control Register"]
@@ -1249,6 +1459,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 0"]
     #[allow(non_camel_case_types)]
@@ -1274,6 +1489,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Miscellaneous Register 0"]
@@ -1301,6 +1521,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 0"]
     #[allow(non_camel_case_types)]
@@ -1326,6 +1551,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Miscellaneous Register 0"]
@@ -1353,6 +1583,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 1"]
     #[allow(non_camel_case_types)]
@@ -1378,6 +1613,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Miscellaneous Register 1"]
@@ -1405,6 +1645,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 1"]
     #[allow(non_camel_case_types)]
@@ -1430,6 +1675,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Miscellaneous Register 1"]
@@ -1457,6 +1707,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 2"]
     #[allow(non_camel_case_types)]
@@ -1482,6 +1737,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Miscellaneous Register 2"]
@@ -1509,6 +1769,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 2"]
     #[allow(non_camel_case_types)]
@@ -1535,6 +1800,11 @@ pub mod ccm_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Miscellaneous Register 2"]
     #[allow(non_camel_case_types)]
@@ -1560,6 +1830,11 @@ pub mod ccm_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl Registers {
@@ -2044,6 +2319,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Status Register"]
     #[allow(non_camel_case_types)]
@@ -2069,6 +2349,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel Control Register"]
@@ -2096,6 +2381,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel Control Register"]
     #[allow(non_camel_case_types)]
@@ -2111,6 +2401,11 @@ pub mod hw_dcp {
         pub fn write(&self, bits: u32) {
             unsafe { ((BASE_ADDRESS + Self::OFFSET) as *mut u32).write_volatile(bits) }
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel Control Register"]
     #[allow(non_camel_case_types)]
@@ -2125,6 +2420,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn write(&self, bits: u32) {
             unsafe { ((BASE_ADDRESS + Self::OFFSET) as *mut u32).write_volatile(bits) }
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Capability 0 Register"]
@@ -2152,6 +2452,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Capability 1 Register"]
     #[allow(non_camel_case_types)]
@@ -2177,6 +2482,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Context Buffer Pointer"]
@@ -2204,6 +2514,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Key Index"]
     #[allow(non_camel_case_types)]
@@ -2229,6 +2544,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Key Data"]
@@ -2256,6 +2576,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Work Packet 0 Status Register"]
     #[allow(non_camel_case_types)]
@@ -2281,6 +2606,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Work Packet 1 Status Register"]
@@ -2308,6 +2638,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Work Packet 2 Status Register"]
     #[allow(non_camel_case_types)]
@@ -2333,6 +2668,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Work Packet 3 Status Register"]
@@ -2360,6 +2700,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Work Packet 4 Status Register"]
     #[allow(non_camel_case_types)]
@@ -2385,6 +2730,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Work Packet 5 Status Register"]
@@ -2412,6 +2762,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Work Packet 6 Status Register"]
     #[allow(non_camel_case_types)]
@@ -2437,6 +2792,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 0 Command Pointer Address Register"]
@@ -2464,6 +2824,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 0 Semaphore Register"]
     #[allow(non_camel_case_types)]
@@ -2489,6 +2854,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 0 Status Register"]
@@ -2516,6 +2886,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 0 Options Register"]
     #[allow(non_camel_case_types)]
@@ -2541,6 +2916,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 1 Command Pointer Address Register"]
@@ -2568,6 +2948,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 1 Semaphore Register"]
     #[allow(non_camel_case_types)]
@@ -2593,6 +2978,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 1 Status Register"]
@@ -2620,6 +3010,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 1 Options Register"]
     #[allow(non_camel_case_types)]
@@ -2645,6 +3040,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 2 Command Pointer Address Register"]
@@ -2672,6 +3072,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 2 Semaphore Register"]
     #[allow(non_camel_case_types)]
@@ -2697,6 +3102,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 2 Status Register"]
@@ -2724,6 +3134,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 2 Options Register"]
     #[allow(non_camel_case_types)]
@@ -2749,6 +3164,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 3 Command Pointer Address Register"]
@@ -2776,6 +3196,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 3 Semaphore Register"]
     #[allow(non_camel_case_types)]
@@ -2801,6 +3226,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Channel 3 Status Register"]
@@ -2828,6 +3258,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Channel 3 Options Register"]
     #[allow(non_camel_case_types)]
@@ -2853,6 +3288,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Debug Select Register"]
@@ -2880,6 +3320,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Debug Data Register"]
     #[allow(non_camel_case_types)]
@@ -2905,6 +3350,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DCP Page Table Register"]
@@ -2932,6 +3382,11 @@ pub mod hw_dcp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DCP Version Register"]
     #[allow(non_camel_case_types)]
@@ -2957,6 +3412,11 @@ pub mod hw_dcp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl Registers {
@@ -3286,6 +3746,11 @@ pub mod gpio {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "GPIO direction register"]
     #[allow(non_camel_case_types)]
@@ -3318,6 +3783,11 @@ pub mod gpio {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "GPIO pad status register"]
@@ -3373,6 +3843,11 @@ pub mod gpio {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "GPIO interrupt configuration register2"]
     #[allow(non_camel_case_types)]
@@ -3406,6 +3881,11 @@ pub mod gpio {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "GPIO interrupt mask register"]
     #[allow(non_camel_case_types)]
@@ -3438,6 +3918,11 @@ pub mod gpio {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "GPIO interrupt status register"]
@@ -3497,6 +3982,11 @@ pub mod gpio {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl<P> Registers<P>
@@ -3762,6 +4252,11 @@ pub mod rng {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "RNGB control register"]
     #[allow(non_camel_case_types)]
@@ -3787,6 +4282,11 @@ pub mod rng {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "RNGB status register"]
@@ -3957,6 +4457,11 @@ pub mod snvs_lp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_LP Control Register"]
     #[allow(non_camel_case_types)]
@@ -3982,6 +4487,11 @@ pub mod snvs_lp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_LP Status Register"]
@@ -4009,6 +4519,11 @@ pub mod snvs_lp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_LP Secure Monotonic Counter MSB Register"]
     #[allow(non_camel_case_types)]
@@ -4034,6 +4549,11 @@ pub mod snvs_lp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_LP Secure Monotonic Counter LSB Register"]
@@ -4061,6 +4581,11 @@ pub mod snvs_lp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_LP General-Purpose Register"]
     #[allow(non_camel_case_types)]
@@ -4086,6 +4611,11 @@ pub mod snvs_lp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl Registers {
@@ -4222,6 +4752,11 @@ pub mod snvs_hp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_HP Command register"]
     #[allow(non_camel_case_types)]
@@ -4247,6 +4782,11 @@ pub mod snvs_hp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_HP Control register"]
@@ -4274,6 +4814,11 @@ pub mod snvs_hp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_HP Status register"]
     #[allow(non_camel_case_types)]
@@ -4299,6 +4844,11 @@ pub mod snvs_hp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_HP Real-Time Counter MSB Register"]
@@ -4326,6 +4876,11 @@ pub mod snvs_hp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_HP Real-Time Counter LSB Register"]
     #[allow(non_camel_case_types)]
@@ -4351,6 +4906,11 @@ pub mod snvs_hp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_HP Time Alarm MSB Register"]
@@ -4378,6 +4938,11 @@ pub mod snvs_hp {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "SNVS_HP Time Alarm LSB Register"]
     #[allow(non_camel_case_types)]
@@ -4403,6 +4968,11 @@ pub mod snvs_hp {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "SNVS_HP Version ID Register 1"]
@@ -4626,6 +5196,11 @@ pub mod uart {
         pub fn write(&self, bits: u32) {
             unsafe { ((P::BASE_ADDRESS + Self::OFFSET) as *mut u32).write_volatile(bits) }
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART Control Register 1"]
     #[allow(non_camel_case_types)]
@@ -4658,6 +5233,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART Control Register 2"]
@@ -4692,6 +5272,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART Control Register 3"]
     #[allow(non_camel_case_types)]
@@ -4724,6 +5309,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART Control Register 4"]
@@ -4758,6 +5348,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART FIFO Control Register"]
     #[allow(non_camel_case_types)]
@@ -4790,6 +5385,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART Status Register 1"]
@@ -4824,6 +5424,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART Status Register 2"]
     #[allow(non_camel_case_types)]
@@ -4856,6 +5461,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART Escape Character Register"]
@@ -4890,6 +5500,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART Escape Timer Register"]
     #[allow(non_camel_case_types)]
@@ -4922,6 +5537,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART BRM Incremental Register"]
@@ -4956,6 +5576,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART BRM Modulator Register"]
     #[allow(non_camel_case_types)]
@@ -4988,6 +5613,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UART Baud Rate Count Register"]
@@ -5043,6 +5673,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART Test Register"]
     #[allow(non_camel_case_types)]
@@ -5076,6 +5711,11 @@ pub mod uart {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UART RS-485 Mode Control Register"]
     #[allow(non_camel_case_types)]
@@ -5108,6 +5748,11 @@ pub mod uart {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl<P> Registers<P>
@@ -5531,6 +6176,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB VBUS Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5556,6 +6206,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB VBUS Detect Register"]
@@ -5583,6 +6238,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB VBUS Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5608,6 +6268,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Charger Detect Register"]
@@ -5635,6 +6300,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Charger Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5660,6 +6330,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Charger Detect Register"]
@@ -5687,6 +6362,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Charger Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5712,6 +6392,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB VBUS Detect Status Register"]
@@ -5767,6 +6452,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Misc Register"]
     #[allow(non_camel_case_types)]
@@ -5792,6 +6482,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Misc Register"]
@@ -5819,6 +6514,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Misc Register"]
     #[allow(non_camel_case_types)]
@@ -5844,6 +6544,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB VBUS Detect Register"]
@@ -5871,6 +6576,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB VBUS Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5896,6 +6606,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB VBUS Detect Register"]
@@ -5923,6 +6638,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB VBUS Detect Register"]
     #[allow(non_camel_case_types)]
@@ -5948,6 +6668,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Charger Detect Register"]
@@ -5975,6 +6700,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Charger Detect Register"]
     #[allow(non_camel_case_types)]
@@ -6000,6 +6730,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Charger Detect Register"]
@@ -6027,6 +6762,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Charger Detect Register"]
     #[allow(non_camel_case_types)]
@@ -6052,6 +6792,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB VBUS Detect Status Register"]
@@ -6107,6 +6852,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Misc Register"]
     #[allow(non_camel_case_types)]
@@ -6132,6 +6882,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB Misc Register"]
@@ -6159,6 +6914,11 @@ pub mod usb_analog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Misc Register"]
     #[allow(non_camel_case_types)]
@@ -6184,6 +6944,11 @@ pub mod usb_analog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Chip Silicon Version"]
@@ -6460,6 +7225,11 @@ pub mod usbnc_usb {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB OTG2 Control Register"]
     #[allow(non_camel_case_types)]
@@ -6485,6 +7255,11 @@ pub mod usbnc_usb {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "OTG1 UTMI PHY Control 0 Register"]
@@ -6512,6 +7287,11 @@ pub mod usbnc_usb {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "OTG2 UTMI PHY Control 0 Register"]
     #[allow(non_camel_case_types)]
@@ -6537,6 +7317,11 @@ pub mod usbnc_usb {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl Registers {
@@ -6706,6 +7491,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Power-Down Register"]
     #[allow(non_camel_case_types)]
@@ -6738,6 +7528,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Power-Down Register"]
@@ -6772,6 +7567,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Power-Down Register"]
     #[allow(non_camel_case_types)]
@@ -6804,6 +7604,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Transmitter Control Register"]
@@ -6838,6 +7643,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Transmitter Control Register"]
     #[allow(non_camel_case_types)]
@@ -6870,6 +7680,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Transmitter Control Register"]
@@ -6904,6 +7719,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Transmitter Control Register"]
     #[allow(non_camel_case_types)]
@@ -6936,6 +7756,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Receiver Control Register"]
@@ -6970,6 +7795,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Receiver Control Register"]
     #[allow(non_camel_case_types)]
@@ -7002,6 +7832,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Receiver Control Register"]
@@ -7036,6 +7871,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Receiver Control Register"]
     #[allow(non_camel_case_types)]
@@ -7068,6 +7908,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY General Control Register"]
@@ -7102,6 +7947,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY General Control Register"]
     #[allow(non_camel_case_types)]
@@ -7134,6 +7984,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY General Control Register"]
@@ -7168,6 +8023,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY General Control Register"]
     #[allow(non_camel_case_types)]
@@ -7200,6 +8060,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Status Register"]
@@ -7234,6 +8099,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Debug Register"]
     #[allow(non_camel_case_types)]
@@ -7266,6 +8136,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "USB PHY Debug Register"]
@@ -7300,6 +8175,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Debug Register"]
     #[allow(non_camel_case_types)]
@@ -7333,6 +8213,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB PHY Debug Register"]
     #[allow(non_camel_case_types)]
@@ -7365,6 +8250,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UTMI Debug Status Register 0"]
@@ -7420,6 +8310,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UTMI Debug Status Register 1"]
     #[allow(non_camel_case_types)]
@@ -7452,6 +8347,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UTMI Debug Status Register 1"]
@@ -7486,6 +8386,11 @@ pub mod usbphy {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "UTMI Debug Status Register 1"]
     #[allow(non_camel_case_types)]
@@ -7518,6 +8423,11 @@ pub mod usbphy {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "UTMI RTL Version"]
@@ -7993,6 +8903,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "General Purpose Timer #0 Controller"]
     #[allow(non_camel_case_types)]
@@ -8025,6 +8940,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "General Purpose Timer #1 Load"]
@@ -8059,6 +8979,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "General Purpose Timer #1 Controller"]
     #[allow(non_camel_case_types)]
@@ -8092,6 +9017,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "System Bus Config"]
     #[allow(non_camel_case_types)]
@@ -8124,6 +9054,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Capability Registers Length"]
@@ -8284,6 +9219,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Status Register"]
     #[allow(non_camel_case_types)]
@@ -8316,6 +9256,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Interrupt Enable Register"]
@@ -8350,6 +9295,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Frame Index"]
     #[allow(non_camel_case_types)]
@@ -8382,6 +9332,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Frame List Base Address"]
@@ -8416,6 +9371,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Device Address"]
     #[allow(non_camel_case_types)]
@@ -8448,6 +9408,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Next Asynch. Address"]
@@ -8482,6 +9447,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint List Address"]
     #[allow(non_camel_case_types)]
@@ -8514,6 +9484,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Programmable Burst Size"]
@@ -8548,6 +9523,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "TX FIFO Fill Tuning"]
     #[allow(non_camel_case_types)]
@@ -8580,6 +9560,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint NAK"]
@@ -8614,6 +9599,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint NAK Enable"]
     #[allow(non_camel_case_types)]
@@ -8646,6 +9636,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Configure Flag Register"]
@@ -8680,6 +9675,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Port Status & Control"]
     #[allow(non_camel_case_types)]
@@ -8712,6 +9712,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "On-The-Go Status & control"]
@@ -8746,6 +9751,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "USB Device Mode"]
     #[allow(non_camel_case_types)]
@@ -8778,6 +9788,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint Setup Status"]
@@ -8812,6 +9827,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Prime"]
     #[allow(non_camel_case_types)]
@@ -8845,6 +9865,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Flush"]
     #[allow(non_camel_case_types)]
@@ -8877,6 +9902,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint Status"]
@@ -8932,6 +9962,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Control0"]
     #[allow(non_camel_case_types)]
@@ -8964,6 +9999,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint Control 1"]
@@ -8998,6 +10038,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Control 2"]
     #[allow(non_camel_case_types)]
@@ -9030,6 +10075,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint Control 3"]
@@ -9064,6 +10114,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Control 4"]
     #[allow(non_camel_case_types)]
@@ -9096,6 +10151,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Endpoint Control 5"]
@@ -9130,6 +10190,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Control 6"]
     #[allow(non_camel_case_types)]
@@ -9163,6 +10228,11 @@ pub mod usb_uog {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Endpoint Control 7"]
     #[allow(non_camel_case_types)]
@@ -9195,6 +10265,11 @@ pub mod usb_uog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl<P> Registers<P>
@@ -9563,6 +10638,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Block Attributes"]
     #[allow(non_camel_case_types)]
@@ -9595,6 +10675,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Command Argument"]
@@ -9629,6 +10714,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Command Transfer Type"]
     #[allow(non_camel_case_types)]
@@ -9661,6 +10751,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Command Response0"]
@@ -9779,6 +10874,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Present State"]
     #[allow(non_camel_case_types)]
@@ -9833,6 +10933,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "System Control"]
     #[allow(non_camel_case_types)]
@@ -9865,6 +10970,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Interrupt Status"]
@@ -9925,6 +11035,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Interrupt Signal Enable"]
     #[allow(non_camel_case_types)]
@@ -9957,6 +11072,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Auto CMD12 Error Status"]
@@ -10033,6 +11153,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Mixer Control"]
     #[allow(non_camel_case_types)]
@@ -10065,6 +11190,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "ADMA Error Status Register"]
@@ -10120,6 +11250,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "DLL (Delay Line) Control"]
     #[allow(non_camel_case_types)]
@@ -10152,6 +11287,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "DLL Status"]
@@ -10207,6 +11347,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Vendor Specific Register"]
     #[allow(non_camel_case_types)]
@@ -10239,6 +11384,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "MMC Boot Register"]
@@ -10273,6 +11423,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Vendor Specific 2 Register"]
     #[allow(non_camel_case_types)]
@@ -10306,6 +11461,11 @@ pub mod usdhc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Tuning Control Register"]
     #[allow(non_camel_case_types)]
@@ -10338,6 +11498,11 @@ pub mod usdhc {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl<P> Registers<P>
@@ -10588,6 +11753,11 @@ pub mod wdog {
         pub fn rmw(&self, f: impl FnOnce(u16) -> u16) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Watchdog Service Register"]
     #[allow(non_camel_case_types)]
@@ -10620,6 +11790,11 @@ pub mod wdog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u16) -> u16) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Watchdog Reset Status Register"]
@@ -10675,6 +11850,11 @@ pub mod wdog {
         pub fn rmw(&self, f: impl FnOnce(u16) -> u16) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Watchdog Miscellaneous Control Register"]
     #[allow(non_camel_case_types)]
@@ -10707,6 +11887,11 @@ pub mod wdog {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u16) -> u16) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     impl<P> Registers<P>
@@ -10884,6 +12069,11 @@ pub mod gicc {
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
         }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
+        }
     }
     #[doc = "Interrupt Priority Mask Register"]
     #[allow(non_camel_case_types)]
@@ -10909,6 +12099,11 @@ pub mod gicc {
         #[allow(unused_unsafe)]
         pub unsafe fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub unsafe fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Interrupt Acknowledge Register"]
@@ -11067,6 +12262,11 @@ pub mod gicd {
         #[allow(unused_unsafe)]
         pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
             self.write(f(self.read()))
+        }
+        #[doc = r" Writes the reset value"]
+        #[allow(unused_unsafe)]
+        pub fn reset(&self) {
+            self.write(Self::RESET_VALUE)
         }
     }
     #[doc = "Interrupt Set-Enable Registers (4 instances)"]

--- a/firmware/imx6ul-pac/src/lib.rs
+++ b/firmware/imx6ul-pac/src/lib.rs
@@ -9515,6 +9515,8 @@ pub mod usdhc {
         pub ADMA_ERR_STATUS: ADMA_ERR_STATUS<P>,
         #[doc = "ADMA System Address"]
         pub ADMA_SYS_ADDR: ADMA_SYS_ADDR<P>,
+        #[doc = "DLL (Delay Line) Control"]
+        pub DLL_CTRL: DLL_CTRL<P>,
         #[doc = "DLL Status"]
         pub DLL_STATUS: DLL_STATUS<P>,
         #[doc = "CLK Tuning Control and Status"]
@@ -10119,6 +10121,39 @@ pub mod usdhc {
             self.write(f(self.read()))
         }
     }
+    #[doc = "DLL (Delay Line) Control"]
+    #[allow(non_camel_case_types)]
+    pub struct DLL_CTRL<P>
+    where
+        P: Peripheral,
+    {
+        _p: PhantomData<P>,
+        _not_send_or_sync: PhantomData<*mut ()>,
+    }
+    impl<P> DLL_CTRL<P>
+    where
+        P: Peripheral,
+    {
+        const OFFSET: usize = 0x60;
+        #[doc = r" Reset value"]
+        pub const RESET_VALUE: u32 = 0x0000_0200;
+        #[doc = r" Performs a single load operation on the memory-mapped register"]
+        pub fn read(&self) -> u32 {
+            unsafe { ((P::BASE_ADDRESS + Self::OFFSET) as *const u32).read_volatile() }
+        }
+        #[doc = r" Performs a single store operation on the memory-mapped register"]
+        #[allow(unused_unsafe)]
+        pub fn write(&self, bits: u32) {
+            unsafe { ((P::BASE_ADDRESS + Self::OFFSET) as *mut u32).write_volatile(bits) }
+        }
+        #[doc = r" Performs a read-modify-write on the memory-mapped register"]
+        #[doc = r""]
+        #[doc = r" This is a short-hand for `self.write(f(self.read()))`"]
+        #[allow(unused_unsafe)]
+        pub fn rmw(&self, f: impl FnOnce(u32) -> u32) {
+            self.write(f(self.read()))
+        }
+    }
     #[doc = "DLL Status"]
     #[allow(non_camel_case_types)]
     pub struct DLL_STATUS<P>
@@ -10398,6 +10433,10 @@ pub mod usdhc {
                     _not_send_or_sync: PhantomData,
                 },
                 ADMA_SYS_ADDR: ADMA_SYS_ADDR {
+                    _p: PhantomData,
+                    _not_send_or_sync: PhantomData,
+                },
+                DLL_CTRL: DLL_CTRL {
                     _p: PhantomData,
                     _not_send_or_sync: PhantomData,
                 },

--- a/firmware/memlog/src/lib.rs
+++ b/firmware/memlog/src/lib.rs
@@ -32,7 +32,7 @@ use pac::gicc::GICC;
 // End users must only ever modify the `consts` type parameter of `B0` and `B1`
 
 /// Circular buffer @ priority 0
-static mut B0: Buffer<BigArray<consts::U2>> = Buffer::new();
+static mut B0: Buffer<BigArray<consts::U4>> = Buffer::new();
 //                                     ^^
 
 /// Circular buffer @ priority !0

--- a/firmware/usbarmory/examples/emmc-mbr.rs
+++ b/firmware/usbarmory/examples/emmc-mbr.rs
@@ -16,7 +16,7 @@ use usbarmory::{
 // like `#[rtfm::app]`
 #[no_mangle]
 fn main() -> ! {
-    let emmc = eMMC::take().expect("eMMC");
+    let emmc = eMMC::take().expect("eMMC").unwrap();
     let mut mbr = MbrDevice::open(emmc).unwrap();
 
     for part_idx in 0..4 {

--- a/firmware/usbarmory/examples/emmc-wfr.rs
+++ b/firmware/usbarmory/examples/emmc-wfr.rs
@@ -5,7 +5,7 @@
 
 use exception_reset as _; // default exception handler
 use panic_serial as _; // panic handler
-use usbarmory::{emmc::eMMC, memlog, memlog_flush_and_reset, storage::Block, time};
+use usbarmory::{emmc::eMMC, memlog, memlog_flush_and_reset, storage::Block};
 
 const BLOCK_NR: u32 = 204800; // an offset of 100MB
 
@@ -14,7 +14,7 @@ const BLOCK_NR: u32 = 204800; // an offset of 100MB
 // like `#[rtfm::app]`
 #[no_mangle]
 fn main() -> ! {
-    let emmc = eMMC::take().expect("eMMC");
+    let emmc = eMMC::take().expect("eMMC").unwrap();
 
     let mut orig = Block::zeroed();
     emmc.read(BLOCK_NR, &mut orig);
@@ -26,8 +26,8 @@ fn main() -> ! {
         .iter_mut()
         .for_each(|byte| *byte = byte.wrapping_add(1));
 
-    emmc.write(BLOCK_NR, &updated);
-    emmc.flush();
+    emmc.write(BLOCK_NR, &updated).unwrap();
+    emmc.flush().unwrap();
 
     let mut fresh = Block::zeroed();
     emmc.read(BLOCK_NR, &mut fresh);

--- a/firmware/usbarmory/examples/emmc-wfr.rs
+++ b/firmware/usbarmory/examples/emmc-wfr.rs
@@ -17,7 +17,7 @@ fn main() -> ! {
     let emmc = eMMC::take().expect("eMMC").unwrap();
 
     let mut orig = Block::zeroed();
-    emmc.read(BLOCK_NR, &mut orig);
+    emmc.read(BLOCK_NR, &mut orig).unwrap();
 
     let mut updated = orig.clone();
 
@@ -30,7 +30,7 @@ fn main() -> ! {
     emmc.flush().unwrap();
 
     let mut fresh = Block::zeroed();
-    emmc.read(BLOCK_NR, &mut fresh);
+    emmc.read(BLOCK_NR, &mut fresh).unwrap();
 
     if updated.bytes[..] == fresh.bytes[..] {
         memlog!("OK @ {:#x}", BLOCK_NR);

--- a/firmware/usbarmory/examples/emmc-wfr.rs
+++ b/firmware/usbarmory/examples/emmc-wfr.rs
@@ -1,0 +1,55 @@
+//! eMMC: check that write, flush, read works as expected
+
+#![no_main]
+#![no_std]
+
+use exception_reset as _; // default exception handler
+use panic_serial as _; // panic handler
+use usbarmory::{emmc::eMMC, memlog, memlog_flush_and_reset, storage::Block, time};
+
+const BLOCK_NR: u32 = 204800; // an offset of 100MB
+
+// NOTE binary interfaces, using `no_mangle` and `extern`, are extremely unsafe
+// as no type checking is performed by the compiler; stick to safe interfaces
+// like `#[rtfm::app]`
+#[no_mangle]
+fn main() -> ! {
+    let emmc = eMMC::take().expect("eMMC");
+
+    let mut orig = Block::zeroed();
+    emmc.read(BLOCK_NR, &mut orig);
+
+    let mut updated = orig.clone();
+
+    updated
+        .bytes
+        .iter_mut()
+        .for_each(|byte| *byte = byte.wrapping_add(1));
+
+    emmc.write(BLOCK_NR, &updated);
+    emmc.flush();
+
+    let mut fresh = Block::zeroed();
+    emmc.read(BLOCK_NR, &mut fresh);
+
+    if updated.bytes[..] == fresh.bytes[..] {
+        memlog!("OK @ {:#x}", BLOCK_NR);
+    } else {
+        memlog!("error @ {:#x}: blocks don't match", BLOCK_NR);
+
+        for i in 0..fresh.bytes.len() {
+            if updated.bytes[i] != fresh.bytes[i] {
+                memlog!(
+                    "@ {:#04x}: initial: {:#04x}, got: {:#04x}, expected: {:#04x}",
+                    i,
+                    orig.bytes[i],
+                    fresh.bytes[i],
+                    updated.bytes[i],
+                );
+            }
+        }
+    }
+
+    // then reset the board to return to the u-boot console
+    memlog_flush_and_reset!();
+}

--- a/firmware/usbarmory/examples/emmc.rs
+++ b/firmware/usbarmory/examples/emmc.rs
@@ -17,16 +17,16 @@ use usbarmory::{emmc::eMMC, memlog, memlog_flush_and_reset, storage::Block};
 // like `#[rtfm::app]`
 #[no_mangle]
 fn main() -> ! {
-    let emmc = eMMC::take().expect("eMMC");
+    let emmc = eMMC::take().expect("eMMC").unwrap();
 
     let mut block = Block::zeroed();
-    emmc.read(0, &mut block);
+    emmc.read(0, &mut block).unwrap();
 
     memlog!("first byte of the first block: {}", block.bytes[0]);
     block.bytes[0] += 1;
 
-    emmc.write(0, &block);
-    emmc.flush();
+    emmc.write(0, &block).unwrap();
+    emmc.flush().unwrap();
 
     // then reset the board to return to the u-boot console
     memlog_flush_and_reset!();

--- a/firmware/usbarmory/src/emmc.rs
+++ b/firmware/usbarmory/src/emmc.rs
@@ -564,7 +564,7 @@ impl eMMC {
         const CMDINX_OFFSET: u8 = 24;
 
         let mut w_cmd = u32::from(cmd.index()) << CMDINX_OFFSET;
-        w_cmd |= u32::from(cmd.typ()) << CMDTYP_OFFSET;
+        w_cmd |= u32::from(cmd.cmdtyp()) << CMDTYP_OFFSET;
         w_cmd |= if cmd.data_present() {
             1 << DPSEL_OFFSET
         } else {

--- a/firmware/usbarmory/src/emmc.rs
+++ b/firmware/usbarmory/src/emmc.rs
@@ -133,6 +133,7 @@ impl eMMC {
             assert_eq!(hs_timing, 1, "switching to high speed mode failed");
 
             // clear FRC_SDCLK_ON before changing the clock
+            const FRC_SDCLK_ON: u32 = 1 << 8;
             emmc.usdhc
                 .VEND_SPEC
                 .rmw(|vend_spec| vend_spec & !FRC_SDCLK_ON);

--- a/firmware/usbarmory/src/emmc.rs
+++ b/firmware/usbarmory/src/emmc.rs
@@ -136,7 +136,7 @@ impl eMMC {
             emmc.blocks =
                 u32::from_le_bytes([ext_csd[212], ext_csd[213], ext_csd[214], ext_csd[215]]);
 
-            emmc.send_command(Command::Switch { data: 0x3B90100 }, false);
+            emmc.send_command(Command::Switch { data: 0x3B9_0100 }, false);
             emmc.wait_response()?;
             card::Status::from(emmc.usdhc.CMD_RSP0.read())?;
 

--- a/firmware/usbarmory/src/emmc/card.rs
+++ b/firmware/usbarmory/src/emmc/card.rs
@@ -1,6 +1,8 @@
 // References
 // - (JESD84-A441) eMMC product standard (MMCA, 4.41)
 
+use core::fmt;
+
 /// Card Specific Data
 #[derive(Debug)]
 pub struct Csd {
@@ -32,6 +34,7 @@ impl Csd {
     /// NOTE for card with capacities greater than 2GB this value may not match
     /// the actual capacity of the card and the EXT_CSD register should be
     /// consulted.
+    #[allow(dead_code)]
     pub fn number_of_blocks(&self) -> u32 {
         (1 << (self.size_mult + 2)) * u32::from(self.size + 1)
     }
@@ -63,15 +66,101 @@ impl From<[u32; 4]> for Csd {
     }
 }
 
-/// Card status
-#[derive(Debug, PartialEq)]
-pub struct Status {
-    pub ready_for_data: bool,
-    pub state: State,
+macro_rules! status {
+	  ($($error:ident : $epos:expr),+;$($status:ident : $spos:expr),+) => {
+        /// Card status
+        #[derive(Clone, Copy)]
+        pub struct Status {
+            pub(crate) bits: u32,
+            pub state: State,
+            $(pub $error: bool,)+
+            $(pub $status: bool,)+
+        }
+
+        impl fmt::Debug for Status {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut s = f.debug_struct("Status");
+                s.field("State", &self.state);
+                $(if self.$error {
+                    s.field(stringify!($error), &true);
+                })+
+                $(if self.$status {
+                    s.field(stringify!($status), &true);
+                })+
+                s.finish()
+            }
+        }
+
+        impl Status {
+            pub fn from(bits: u32) -> Result<Self, Self> {
+                let state = match (bits >> 9) & 0b1111 {
+                    0 => State::Idle,
+                    1 => State::Ready,
+                    2 => State::Identification,
+                    3 => State::Standby,
+                    4 => State::Transfer,
+                    5 => State::SendingData,
+                    6 => State::ReceiveData,
+                    7 => State::Programming,
+                    _ => State::Other,
+                };
+
+                let error_mask = $(1 << $epos)|*;
+                let has_errors = bits & error_mask != 0;
+
+                $(let $error = bits & (1 << $epos) != 0;)+
+                $(let $status = bits & (1 << $spos) != 0;)+
+                let status = Self {
+                    bits,
+                    state,
+                    $($error,)+
+                    $($status,)+
+                };
+
+                if has_errors {
+                    Err(status)
+                } else {
+                    Ok(status)
+                }
+            }
+        }
+	  };
 }
 
+impl PartialEq for Status {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.bits == rhs.bits
+    }
+}
+
+status!(
+    address_out_of_range: 31,
+    address_misalign: 30,
+    block_len_error: 29,
+    erase_seq_error: 28,
+    erase_param: 27,
+    wp_violation: 26,
+    lock_unlock_failed: 24,
+    com_crc_error: 23,
+    illegal_command: 22,
+    card_ecc_failed: 21,
+    cc_error: 20,
+    error: 19,
+    underrun: 18,
+    overrun: 17,
+    cid_csd_overwrite: 16,
+    wp_erase_skip: 15,
+    erase_reset: 13,
+    switch_error: 7;
+
+    card_is_locked: 25,
+    ready_for_data: 8,
+    urgent_bkops: 6,
+    app_cmd: 5
+);
+
 /// Card state
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum State {
     Idle,
     Ready,
@@ -82,27 +171,4 @@ pub enum State {
     ReceiveData,
     Programming,
     Other,
-}
-
-impl From<u32> for Status {
-    fn from(bits: u32) -> Self {
-        const READY_FOR_DATA: u32 = 1 << 8;
-        let ready_for_data = bits & READY_FOR_DATA != 0;
-        let state = match (bits >> 9) & 0b1111 {
-            0 => State::Idle,
-            1 => State::Ready,
-            2 => State::Identification,
-            3 => State::Standby,
-            4 => State::Transfer,
-            5 => State::SendingData,
-            6 => State::ReceiveData,
-            7 => State::Programming,
-            _ => State::Other,
-        };
-
-        Self {
-            ready_for_data,
-            state,
-        }
-    }
 }

--- a/firmware/usbarmory/src/emmc/card.rs
+++ b/firmware/usbarmory/src/emmc/card.rs
@@ -64,7 +64,7 @@ impl From<[u32; 4]> for Csd {
 }
 
 /// Card status
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Status {
     pub ready_for_data: bool,
     pub state: State,

--- a/firmware/usbarmory/src/emmc/cmd.rs
+++ b/firmware/usbarmory/src/emmc/cmd.rs
@@ -82,7 +82,7 @@ enum Type {
 
 #[derive(PartialEq)]
 enum Response {
-    NoResponse,
+    None,
     R1,
     R1b,
     R2,
@@ -116,7 +116,7 @@ impl Command {
     // see table 56-3
     fn response(&self) -> Response {
         match self {
-            Command::GoIdleState => Response::NoResponse,
+            Command::GoIdleState => Response::None,
             Command::SendOpCond { .. } => Response::R3,
             Command::AllSendCid => Response::R2,
             Command::SetRelativeAddr { .. } => Response::R1, // eMMC (SDIO uses R6)
@@ -201,7 +201,7 @@ impl Command {
         const B48_RESPONSE_CHECK_BUSY: u8 = 0b11;
 
         match self.response() {
-            Response::NoResponse => NO_RESPONSE,
+            Response::None => NO_RESPONSE,
             Response::R2 => B136_RESPONSE,
             Response::R3 | Response::R4 => B48_RESPONSE,
             Response::R1 | Response::R5 | Response::R6 => B48_RESPONSE,
@@ -213,7 +213,7 @@ impl Command {
     // see table 56-6
     pub fn cicen(&self) -> bool {
         match self.response() {
-            Response::NoResponse => false,
+            Response::None => false,
             Response::R2 => false,
             Response::R3 | Response::R4 => false,
             Response::R1 | Response::R5 | Response::R6 => true,
@@ -224,7 +224,7 @@ impl Command {
     /// Check command CRC in the response
     pub fn cccen(&self) -> bool {
         match self.response() {
-            Response::NoResponse => false,
+            Response::None => false,
             Response::R2 => true,
             Response::R3 | Response::R4 => false,
             Response::R1 | Response::R5 | Response::R6 => true,

--- a/firmware/usbarmory/src/emmc/cmd.rs
+++ b/firmware/usbarmory/src/emmc/cmd.rs
@@ -25,14 +25,8 @@ pub enum Command {
 
     // 6
     // NOTE MMC specific version; `SWITCH_FUNC` is the SD variant of the command
-    #[allow(dead_code)] // will be used to change the speed and data width
     Switch {
-        /// `u2`
-        access: u8,
-        index: u8,
-        value: u8,
-        /// `u3`
-        cmd: u8,
+        data: u32,
     },
 
     // 7
@@ -167,17 +161,7 @@ impl Command {
             Command::SendStatus { rca } => u32::from(rca.get()) << 16,
             Command::SetBlockLen { len } => *len,
             Command::SetRelativeAddr { rca } => u32::from(rca.get()) << 16,
-            Command::Switch {
-                access,
-                index,
-                value,
-                cmd,
-            } => {
-                (u32::from(*access) << 24)
-                    | (u32::from(*index) << 16)
-                    | (u32::from(*value) << 8)
-                    | u32::from(*cmd)
-            }
+            Command::Switch { data } => *data,
             Command::WriteSingleBlock { block_nr } => *block_nr,
         }
     }

--- a/firmware/usbarmory/src/storage.rs
+++ b/firmware/usbarmory/src/storage.rs
@@ -61,6 +61,7 @@ pub const BLOCK_SIZE: u16 = 512;
 
 /// A copy of an eMMC/SD card block.
 #[repr(align(4))]
+#[derive(Clone)]
 pub struct Block {
     /// The bytes contained in the memory block.
     pub bytes: [u8; BLOCK_SIZE as usize],

--- a/host/txt2rust/src/codegen.rs
+++ b/host/txt2rust/src/codegen.rs
@@ -117,6 +117,25 @@ pub fn krate(peripherals: &[Peripheral]) -> TokenStream2 {
                         .reset_value
                         .map(|rv| {
                             let rv = unsuffixed_hex(rv, false);
+
+                            if reg.access == Access::ReadWrite || reg.access == Access::WriteOnly {
+                                let unsafety = if reg.unsafe_write {
+                                    quote!(unsafe)
+                                } else {
+                                    quote!()
+                                };
+
+                                methods.push(quote!(
+                                    /// Writes the reset value
+                                    #[allow(unused_unsafe)]
+                                    pub #unsafety fn reset(
+                                        &self , #iparam
+                                    ) {
+                                        self.write(#iarg Self::RESET_VALUE)
+                                    }
+                                ));
+                            }
+
                             quote!(
                                 /// Reset value
                                 pub const RESET_VALUE: #uxx = #rv;
@@ -318,6 +337,25 @@ pub fn krate(peripherals: &[Peripheral]) -> TokenStream2 {
                         .reset_value
                         .map(|rv| {
                             let rv = unsuffixed_hex(rv, false);
+
+                            if reg.access == Access::ReadWrite || reg.access == Access::WriteOnly {
+                                let unsafety = if reg.unsafe_write {
+                                    quote!(unsafe)
+                                } else {
+                                    quote!()
+                                };
+
+                                methods.push(quote!(
+                                    /// Writes the reset value
+                                    #[allow(unused_unsafe)]
+                                    pub #unsafety fn reset(
+                                        &self , #iparam
+                                    ) {
+                                        self.write(#iarg Self::RESET_VALUE)
+                                    }
+                                ));
+                            }
+
                             quote!(
                                 /// Reset value
                                 pub const RESET_VALUE: #uxx = #rv;

--- a/host/txt2rust/src/parse.rs
+++ b/host/txt2rust/src/parse.rs
@@ -64,11 +64,12 @@ fn line<'a>(line: &'a str, prev: Option<&'a str>, next: Option<&'a str>) -> Opti
         let next = next.expect("found split row; next line is required").trim();
 
         let (description, name) = if next.contains('(') && next.contains(')') {
-            let mut next_parts = next.splitn(2, '(');
-            let more_description = next_parts.next().expect("UNREACHABLE").trim();
-
+            // split from the right because the description may contain parenthesis
+            let mut next_parts = next.rsplitn(2, '(');
             let mut parts = next_parts.next().expect("UNREACHABLE").splitn(2, ')');
             let name = parts.next().expect("UNREACHABLE");
+
+            let more_description = next_parts.next().expect("UNREACHABLE").trim();
 
             let mut parts = prev.rsplitn(2, ' ');
             let last = parts.next().unwrap_or("");
@@ -92,9 +93,10 @@ fn line<'a>(line: &'a str, prev: Option<&'a str>, next: Option<&'a str>) -> Opti
 
         (description, name, width, parts.next()?.trim())
     } else {
-        let mut parts = rest.splitn(2, '(');
-        let description = parts.next()?.trim();
+        // split from the right because the description may contain parenthesis
+        let mut parts = rest.rsplitn(2, '(');
         let rest = parts.next()?;
+        let description = parts.next()?.trim();
 
         let mut parts = rest.splitn(2, ')');
         let name = parts.next()?;


### PR DESCRIPTION
this improves error checking (we were not fully checking all the error flags in the Card Status Register) and changes the signature of most methods to return a `Result`

it also changes the default clock frequency to 48 MHz (from 400 KHz)

it also fixes the `read` and `write` bounds checks by actually reading the extended Card Specific Data register to get the number of blocks in the card