### PR TITLE
small program to interact with the Armory in USB downloader mode

### DIFF
--- a/host/runner2/Cargo.toml
+++ b/host/runner2/Cargo.toml
@@ -14,3 +14,4 @@ xmas-elf = "0.7.0"
 serialport = { version = "3.3.0", default-features = false }
 image = { path = "../image" }
 tempfile = "3.1.0"
+hidapi = "1.2.1"

--- a/host/runner2/src/bin/test-drive.rs
+++ b/host/runner2/src/bin/test-drive.rs
@@ -1,0 +1,30 @@
+use core::str;
+
+use runner2::sdp::Sdp;
+
+fn main() {
+    println!("> attempting to claim USB device (this should complete in less than 4 seconds)");
+    let sdp = Sdp::open().expect("failed to open USB device. Is the Armory in 'eMMC' boot mode and connected to your PC? Does the USB device `15a2:0080` show under `lsusb`?");
+    println!("> performing an HID exchange with the USB device to read part of the ROM");
+    let mut bytes = vec![];
+    let word = sdp.read_memory(0x84).expect("couldn't read device memory");
+    bytes.extend_from_slice(&word.to_le_bytes());
+    println!("> first HID exchanged succeeded; performing some more");
+    let mut addr = 0x88;
+    let end = 0xb0;
+    while addr < end {
+        let word = sdp.read_memory(addr).expect("couldn't read device memory");
+        bytes.extend_from_slice(&word.to_le_bytes());
+        addr += 4;
+    }
+    println!("> printing the data we just read. You should see a string");
+    if let Ok(s) = str::from_utf8(&bytes) {
+        println!("{:?}", s);
+    } else {
+        println!("{:?}", bytes);
+    }
+
+    println!("> releasing USB device (this should NOT take several seconds)");
+    drop(sdp);
+    println!("> all done!");
+}

--- a/host/runner2/src/lib.rs
+++ b/host/runner2/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod hid;
+pub mod sdp;


### PR DESCRIPTION
Steps to try this program:

- zero the first sectors of the internal eMMC using u-boot; see [the README](https://github.com/iqlusioninc/usbarmory.rs/tree/develop/firmware/usbarmory#flashing-the-image-1)
- put the Armory in "eMMC" boot mode
- check that the USB device with VID:PID `15a2:0080` shows under `lsusb`
- (basically the Armory should be "development mode" where the Cargo runner works)
- now navigate to the `runner2` directory and run the `test-drive` program:
``` console
$ cd host/runner2
$ cargo run --bin test-drive
```
You should see the following output:
``` text
> attempting to claim USB device (this should complete in less than 4 seconds)
> performing an HID exchange with the USB device to read part of the ROM
> first HID exchanged succeeded; performing some more
> printing the data we just read. You should see a string
"Copyright (C) 2016-2017, NXP Semiconductor. "
> releasing USB device (this should NOT take several seconds)
> all done!
```