### PR TITLE
[WIP] transactional filesystem

### DIFF
--- a/firmware/usbarmory/Cargo.toml
+++ b/firmware/usbarmory/Cargo.toml
@@ -20,16 +20,29 @@ name = "emmc-fs2"
 required-features = ["fs"]
 
 [[example]]
+name = "emmc-fs3"
+required-features = ["fs"]
+
+[[example]]
+name = "emmc-fs4"
+required-features = ["fs"]
+
+[[example]]
+name = "emmc-tfs"
+required-features = ["fs"]
+
+[[example]]
 name = "emmc-fs-format"
 required-features = ["fs"]
 
 [dependencies]
 arrayref = "0.3.6"
 block-cipher-trait = "0.6.2"
-consts = { path = "../../common/consts" }
 c-stubs = { path = "../../common/c-stubs" }
+consts = { path = "../../common/consts" }
 cortex-a = { path = "../cortex-a" }
 digest = "0.8.1"
+generic-array = "0.13.2"
 heapless = "0.5.3"
 memlog = { path = "../memlog" }
 rand_core = "0.5.1"
@@ -49,8 +62,8 @@ path = "../imx6ul-pac"
 [dependencies.usbarmory-rt]
 path = "../usbarmory-rt"
 ## choose the location of the .text and .rodata sections -- pick only one line
-# features = ["dram"]
-features = ["ocram"]
+features = ["dram"]
+# features = ["ocram"]
 
 [dev-dependencies]
 as-slice = "0.1.3"

--- a/firmware/usbarmory/examples/emmc-tfs.rs
+++ b/firmware/usbarmory/examples/emmc-tfs.rs
@@ -1,0 +1,93 @@
+//! Check that we can work with multiple opened files
+//!
+//! NOTE if you haven't already create an MBR partition (`emmc-new-mbr` example) and format the
+//! partition (`emmc-fs-format` example) before running this; otherwise you'll run into a "corrupted
+//! filesystem" error
+
+#![no_main]
+#![no_std]
+
+use exception_reset as _; // default exception handler
+use panic_serial as _; // panic handler
+use usbarmory::{
+    emmc::eMMC,
+    fs::{consts, transactional, File, FileAlloc, LittleFs, LittleFsAlloc},
+    memlog, memlog_flush_and_reset,
+    storage::MbrDevice,
+};
+
+static FILE1: &str = "a.txt";
+static FILE2: &str = "b.txt";
+static FILE3: &str = "c.txt";
+static TESTSTR: &[u8] = b"Hello File!";
+
+// NOTE binary interfaces, using `no_mangle` and `extern`, are extremely unsafe
+// as no type checking is performed by the compiler; stick to safe interfaces
+// like `#[rtfm::app]`
+#[no_mangle]
+fn main() -> ! {
+    let emmc = eMMC::take().expect("eMMC").unwrap();
+
+    let mut mbr = MbrDevice::open(emmc).unwrap();
+    let mut main_part = mbr.partition(0).unwrap();
+
+    let mut fsa = LittleFsAlloc::default();
+    let fs = LittleFs::mount(&mut fsa, &mut main_part).unwrap();
+    memlog!("fs mounted");
+
+    let mut f1_ = FileAlloc::new();
+    let mut f2_ = FileAlloc::new();
+    let mut f3_ = FileAlloc::new();
+
+    // we need to create the files before we enter transactional mode
+    File::create(&fs, &mut f1_, FILE1).unwrap();
+    memlog!("created f1");
+    File::create(&fs, &mut f2_, FILE2).unwrap();
+    memlog!("created f2");
+    File::create(&fs, &mut f3_, FILE3).unwrap();
+    memlog!("created f3");
+
+    // allows up to 3 open files
+    let fs = fs.transactional::<consts::U3>();
+    memlog!("entered transactional mode");
+
+    let f1 = transactional::File::open(&fs, &mut f1_, FILE1).unwrap();
+    f1.write(TESTSTR).unwrap();
+    memlog!("wrote data to file1");
+
+    let f2 = transactional::File::open(&fs, &mut f2_, FILE2).unwrap();
+    f2.write(TESTSTR).unwrap();
+    memlog!("wrote data to file2");
+
+    let f3 = transactional::File::open(&fs, &mut f3_, FILE3).unwrap();
+    f3.write(TESTSTR).unwrap();
+    memlog!("wrote data to file3");
+
+    let fs = fs.sync().unwrap();
+    memlog!("synced all files -- exiting transactional mode");
+
+    let f1 = File::open(&fs, &mut f1_, FILE1).unwrap();
+    let f2 = File::open(&fs, &mut f2_, FILE2).unwrap();
+    let f3 = File::open(&fs, &mut f3_, FILE3).unwrap();
+
+    let mut buf = [0; 32];
+    for f in [f1, f2, f3].iter_mut() {
+        assert_eq!(
+            f.len().unwrap(),
+            TESTSTR.len(),
+            "file length doesn't match our expectations"
+        );
+
+        let n = f.read(&mut buf).unwrap();
+        assert_eq!(
+            &buf[..n],
+            TESTSTR,
+            "file contents don't match our expectations"
+        );
+    }
+
+    memlog!("DONE");
+
+    // then reset the board
+    memlog_flush_and_reset!();
+}

--- a/firmware/usbarmory/src/emmc.rs
+++ b/firmware/usbarmory/src/emmc.rs
@@ -849,6 +849,8 @@ impl ManagedBlockDevice for eMMC {
             return Err(Error::Other);
         }
 
+        memlog!("write(lba={:#x})", lba);
+
         Self::write(self, lba as u32, block)?;
         Ok(())
     }

--- a/firmware/usbarmory/src/fs/transactional.rs
+++ b/firmware/usbarmory/src/fs/transactional.rs
@@ -1,0 +1,215 @@
+//! Transactional FS
+
+use core::{
+    cell::{Cell, UnsafeCell},
+    mem::MaybeUninit,
+    ptr::NonNull,
+};
+
+use generic_array::GenericArray;
+use heapless::ArrayLength;
+use littlefs2::{
+    fs::{self, SeekFrom},
+    io::{self, Read, Seek, Write},
+};
+
+use super::{FileAlloc, LfsStorage, LittleFs};
+use crate::storage::ManagedBlockDevice;
+
+/// Transactional FS
+///
+/// This FS does NOT allow `fs`-style operations like `create_dir` and `remove` that require writing
+/// to the eMMC. It does allow `File` write operations but those will be cached to memory and only
+/// be committed to the eMMC when the `sync` method (which consumes `self`) is called
+pub struct Fs<'fs, 'f, D, N>
+where
+    D: ManagedBlockDevice,
+    N: ArrayLength<File<'f, 'fs, D>>,
+{
+    littlefs: LittleFs<'fs, D>,
+    files: Arena<File<'f, 'fs, D>, N>,
+}
+
+/// An open file.
+///
+/// All writes to this file will be cached in memory until `Fs.sync` is called
+pub struct File<'f, 'fs, D>
+where
+    D: ManagedBlockDevice,
+    'fs: 'f,
+{
+    file: fs::File<'f, LfsStorage<D>>,
+
+    // NOTE this field (`self.fs`) is a pointer into `Fs.littlefs` where `self` (this file) will be
+    // allocated in `Fs.arena` (the other field of the *same* `Fs` instance). The `File` type will
+    // only ever appear in user code as the mutable reference `&'Fs mut File` where `'Fs` is the
+    // lifetime of the `Fs` instance that holds the actual `File` instance.
+    //
+    // Given that (a) `&'Fs mut File` can NOT outlive `Fs` because of the `'Fs` lifetime, (b) one cannot
+    // move `Fs` while `&'Fs mut File` exists and (c) the `File` instance will be deallocated at the
+    // same time as the `Fs` instance and , it follows that accessing this `fs` field will NOT
+    // result in accessing deallocated memory. Note that other borrow checking invariants need to be
+    // enforced manually (e.g. safe public API must not create references with lifetime greater than
+    // `'Fs` from this raw pointer; also Rust aliasing rules need to be enforced)
+    littlefs: NonNull<LittleFs<'fs, D>>,
+}
+
+impl<'f, 'fs, D> File<'f, 'fs, D>
+where
+    D: ManagedBlockDevice,
+{
+    /// Opens the file at `path`.
+    pub fn open<'lfs, N>(
+        fs: &'lfs Fs<'fs, 'f, D, N>,
+        alloc: &'f mut FileAlloc<D>,
+        path: impl AsRef<[u8]>,
+    ) -> io::Result<&'lfs mut Self>
+    where
+        N: ArrayLength<File<'f, 'fs, D>>,
+    {
+        let mut lf = fs::File::open(
+            path.as_ref(),
+            &mut alloc.inner,
+            &mut fs.littlefs.fs.borrow_mut(),
+            &mut fs.littlefs.storage.borrow_mut(),
+        )?;
+        lf.seek(
+            &mut fs.littlefs.fs.borrow_mut(),
+            &mut fs.littlefs.storage.borrow_mut(),
+            SeekFrom::Start(0),
+        )?;
+        let f = File {
+            file: lf,
+            littlefs: NonNull::from(&fs.littlefs),
+        };
+        Ok(fs.files.alloc(f)?)
+    }
+
+    /// Returns the length of this file in Bytes.
+    pub fn len(&mut self) -> io::Result<usize> {
+        // NOTE(unsafe) this *shared* reference (`&'_`) will only be used within the scope of this
+        // function and the `write` operation is blocking
+        let littlefs = unsafe { self.littlefs.as_ref() };
+        self.file.len(
+            &mut littlefs.fs.borrow_mut(),
+            &mut littlefs.storage.borrow_mut(),
+        )
+    }
+
+    /// Reads bytes from this file into `buf`.
+    pub fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // NOTE(unsafe) this *shared* reference (`&'_`) will only be used within the scope of this
+        // function and the `write` operation is blocking
+        let littlefs = unsafe { self.littlefs.as_ref() };
+        self.file.read(
+            &mut littlefs.fs.borrow_mut(),
+            &mut littlefs.storage.borrow_mut(),
+            buf,
+        )
+    }
+
+    /// Writes byte from `buf` into this file.
+    ///
+    /// The data will be cached in memory and only be committed to disk when `Fs.sync` is called
+    pub fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        // NOTE(unsafe) this *shared* reference (`&'_`) will only be used within the scope of this
+        // function and the `write` operation is blocking
+        let littlefs = unsafe { self.littlefs.as_ref() };
+        self.file.write(
+            &mut littlefs.fs.borrow_mut(),
+            &mut littlefs.storage.borrow_mut(),
+            bytes,
+        )
+    }
+}
+
+impl<'fs, 'f, D, N> Fs<'fs, 'f, D, N>
+where
+    D: ManagedBlockDevice,
+    N: ArrayLength<File<'f, 'fs, D>>,
+{
+    pub(crate) fn wrap(littlefs: LittleFs<'fs, D>) -> Self {
+        Self {
+            littlefs,
+            files: Arena::new(),
+        }
+    }
+
+    /// Returns the available space in Bytes (approximated).
+    #[cfg(untested)]
+    pub fn available_space(&self) -> io::Result<u64> {
+        self.littlefs
+            .fs
+            .borrow_mut()
+            .available_space(&mut self.littlefs.storage.borrow_mut())
+            .map(|space| space as u64)
+    }
+
+    /// Returns an iterator over the contents of the directory at `path`.
+    #[cfg(untested)]
+    pub fn read_dir<'r>(&'r self, path: impl AsRef<[u8]>) -> io::Result<ReadDir<'r, 'fs, D>> {
+        self.littlefs
+            .fs
+            .borrow_mut()
+            .read_dir(path.as_ref(), &mut self.littlefs.storage.borrow_mut())
+            .map(move |inner| ReadDir {
+                fs: &self.littlefs,
+                inner,
+            })
+    }
+
+    /// Commits all pending file writes to the eMMC
+    ///
+    /// NOTE this will synchronize *one file at a time* and *in the order they were opened* (from
+    /// first opened to last opened)
+    pub fn sync(mut self) -> io::Result<LittleFs<'fs, D>> {
+        // can perform eMMC writes again
+        self.littlefs.storage.borrow_mut().read_only = false;
+        let bufferp = self.files.buffer.get() as *mut File<'f, 'fs, D>;
+        let n = self.files.pos.get();
+        for i in 0..n {
+            // NOTE(unsafe) OK to move out the `File` because we are consuming the `files` arena
+            let f = unsafe { bufferp.add(i).read() };
+            // NB `f.fs` is likely a dangling pointer by now so use `self.littlefs` instead
+            f.file
+                .close(self.littlefs.fs.get_mut(), self.littlefs.storage.get_mut())?;
+        }
+        Ok(self.littlefs)
+    }
+}
+
+// a heapless Arena
+// NOTE this is missing a `Drop` implementation but it doesn't matter because we'll `close` all
+// files by hand (rather than relying on destructors running) in `Fs.sync`
+struct Arena<T, N>
+where
+    N: ArrayLength<T>,
+{
+    buffer: UnsafeCell<MaybeUninit<GenericArray<T, N>>>,
+    pos: Cell<usize>,
+}
+
+impl<T, N> Arena<T, N>
+where
+    N: ArrayLength<T>,
+{
+    fn new() -> Self {
+        Self {
+            buffer: UnsafeCell::new(MaybeUninit::uninit()),
+            pos: Cell::new(0),
+        }
+    }
+
+    fn alloc(&self, value: T) -> io::Result<&mut T> {
+        let i = self.pos.get();
+        if i < N::USIZE {
+            let bufferp = self.buffer.get() as *mut T;
+            unsafe { bufferp.add(i).write(value) }
+            self.pos.set(i + 1);
+            Ok(unsafe { &mut *bufferp.add(i) })
+        } else {
+            // OOM -- `Error` variant is not quite right but will make do
+            Err(io::Error::NoMemory)
+        }
+    }
+}


### PR DESCRIPTION
this PR adds a `transactional::Fs` newtype over the existing `LittleFs` API.

In "transactional" mode, the filesystem only exposes read-only `fs` operations (like `read_dir` and *opening*, not creating, a file). File writes are also allowed in this mode but they'll be cached to memory. The `Fs.sync` method ends the transactional mode by consuming the newtype and returning the original `LittleFs` value; `Fs.sync` will commit all pending file writes to the eMMC (\*)

(\*) *fine print* synchronizing *all* the files is NOT guaranteed to be atomic: the files will be synchronized to disk *one by one*. If power is lost during this operation some files may end up updated while others not -- littlefs ensures the files won't be corrupted in this scenario. 

Although neither littlefs or the eMMC provides a way to atomically update a group of files (as these may live in different eMMC sectors), it should still be possible to implement such functionality on top of `transactional::Fs`. For instance something like the code below would check whether a group of files has been atomically updated or not.

``` rust
// omitted creating files a.txt, b.txt, c.txt and .lock outside the transactional mode

// we are about to modify the files a, b and c so indicate that state in `.lock`
File::create(&fs, &mut fa1, ".lock")?.write(b"WIP")?.close()?;

let tfs = fs.transactional::<consts::U4>()?;
let a = tFile::create(&tfs, &mut fa2, "a.txt")
// repeat for b.txt, c.txt and .lock
// do stuff with files a, b and c

// as the last step of `Fs.sync` put the `.lock` file in "atomic update succeeded"
lock.write(b"DONE")?;

// sync files in this order: a, b, c and lock
tfs.sync()?;
```

Before reading files a, b or c one would check if `.lock` contains "WIP", which means the atomic file group update failed (e.g. because power was lost before `.lock` was updated in the last line of the previous snippet), or "DONE", which means the atomic file group update succeeded.

With checked atomic file group updates one could implement a revision, or backup, system for a group of files.

TODO
- [ ] test fs API
- [ ] remove print statement from `storage.rs`
- [ ] document that `transactional::File.write` can fail due to the file cache being too small
