### PR TITLE
Fix badges and links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,6 @@ anyone can contribute regardless of race, gender, or sexual orientation.
 If you observe harassment which you do not think is being addressed, please
 [contact us] and we will seek to remedy the situation.
 
-[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/armistice/blob/develop/CODE_OF_CONDUCT.md
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/usbarmory.rs/blob/develop/CODE_OF_CONDUCT.md
 [pull request]: https://help.github.com/articles/about-pull-requests/
 [contact us]: mailto:oss@iqlusion.io

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ without any additional terms or conditions.
 [build-image]: https://github.com/iqlusioninc/usbarmory.rs/workflows/Rust/badge.svg?branch=develop&event=push
 [build-link]: https://github.com/iqlusioninc/usbarmory.rs/actions
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-blue.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 
@@ -51,7 +50,7 @@ without any additional terms or conditions.
 
 [usbarmory]: https://github.com/f-secure-foundry/usbarmory/wiki
 [F-Secure]: https://foundry.f-secure.com/
-[CONTRIBUTING.md]: https://github.com/iqlusioninc/armistice/blob/develop/CONTRIBUTING.md
-[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/armistice/blob/develop/CODE_OF_CONDUCT.md
+[CONTRIBUTING.md]: https://github.com/iqlusioninc/usbarmory.rs/blob/develop/CONTRIBUTING.md
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/usbarmory.rs/blob/develop/CODE_OF_CONDUCT.md
 [Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [MIT license]: https://opensource.org/licenses/MIT

--- a/firmware/usbarmory/README.md
+++ b/firmware/usbarmory/README.md
@@ -527,8 +527,7 @@ without any additional terms or conditions.
 [docs-image]: https://docs.rs/usbarmory/badge.svg
 [docs-link]: https://docs.rs/usbarmory/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[license-link]: https://github.com/iqlusioninc/armistice/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.42+-red.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.42+-blue.svg
 [gitter-image]: https://badges.gitter.im/iqlusioninc/community.svg
 [gitter-link]: https://gitter.im/iqlusioninc/community
 
@@ -536,7 +535,8 @@ without any additional terms or conditions.
 
 [usbarmory]: https://github.com/f-secure-foundry/usbarmory/wiki
 [F-Secure]: https://foundry.f-secure.com/
-[CONTRIBUTING.md]: https://github.com/iqlusioninc/armistice/blob/develop/CONTRIBUTING.md
-[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/armistice/blob/develop/CODE_OF_CONDUCT.md
+[flip-lld]: https://github.com/japaric/flip-lld
+[CONTRIBUTING.md]: https://github.com/iqlusioninc/usbarmory.rs/blob/develop/CONTRIBUTING.md
+[CODE_OF_CONDUCT.md]: https://github.com/iqlusioninc/usbarmory.rs/blob/develop/CODE_OF_CONDUCT.md
 [Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [MIT license]: https://opensource.org/licenses/MIT


### PR DESCRIPTION
- Make 1.42 MSRV badges blue now that it's released
- Fix `armistice` => `usbarmory.rs` copypasta links
- Linkify `flip-lld`