### PR TITLE
usd-runner: sort candidate serial devices

### DIFF
--- a/host/usd/src/bin/usd-runner.rs
+++ b/host/usd/src/bin/usd-runner.rs
@@ -113,6 +113,8 @@ fn redirect() -> Result<(), anyhow::Error> {
         }
     }
 
+    candidates.sort();
+
     if let Some(path) = candidates.get(DEVNO) {
         let mut serial = serialport::open_with_settings(path, &settings)?;
 


### PR DESCRIPTION
Without sorting (on macOS):

    [usd/src/bin/usd-runner.rs:116] &candidates = [
        "/dev/tty.usbserial-14302",
        "/dev/tty.usbserial-14300",
        "/dev/tty.usbserial-14301",
        "/dev/tty.usbserial-14303",
    ]

With sorting:

    [usd/src/bin/usd-runner.rs:117] &candidates = [
        "/dev/tty.usbserial-14300",
        "/dev/tty.usbserial-14301",
        "/dev/tty.usbserial-14302",
        "/dev/tty.usbserial-14303",
    ]