### PR TITLE
macOS: use baud rate of 3,000,000 (supported by Apple driver)

### DIFF
--- a/firmware/usbarmory-rt/src/serial.rs
+++ b/firmware/usbarmory-rt/src/serial.rs
@@ -51,8 +51,9 @@ pub fn init() {
         // reference clock is input divided by 1 (80 MHz); DCE mode
         uart.UFCR.write(0x0a81);
 
-        uart.UBIR.write(0xf);
-        uart.UBMR.write(20 - 1);
+        // configure baud rate: 3,000,000 baud (TODO: use 4Mbaud on Linux hosts)
+        uart.UBIR.write(2);
+        uart.UBMR.write(4);
 
         uart.UMCR.write(0);
 

--- a/host/usd/src/bin/usd-runner.rs
+++ b/host/usd/src/bin/usd-runner.rs
@@ -98,7 +98,7 @@ fn redirect() -> Result<(), anyhow::Error> {
     const VID: u16 = 0x0403; // Future Technology Devices International, Ltd
     const PID: u16 = 0x6011; // FT4232H Quad HS USB-UART/FIFO IC
     const DEVNO: usize = 2; // device #3 is the one we want
-    const BAUD_RATE: u32 = 4_000_000;
+    const BAUD_RATE: u32 = 3_000_000; // max baud rate supported on macOS (TODO: 4Mbaud on Linux hosts)
     const BUFSZ: usize = 512; // the FT4232H uses 512B USB packets
 
     let mut settings = SerialPortSettings::default();


### PR DESCRIPTION
4 megabaud is not supported by the Apple-supplied driver is used for FT4232H (AppleIntelCNLUSBXHCI). Per the [discussion on #63](https://github.com/iqlusioninc/usbarmory.rs/issues/63#issuecomment-612493292), installing the FTDI driver is basically unworkable because the signature fails to verify, which has been reproduced by several other people. It seems the options are:

1. If you have an Apple Developer ID, sign it yourself (we don't but maybe we should!)
2. Disable system protections 😱  
3. Give up and accept the limitations of the Apple driver

We can look into the first option but for now I just tried to make things work with the Apple driver.

~~I semi-arbitrarily picked 128 kbaud as a standard baud rate and one which divides evenly into the 80MHz reference clock (by 625), and that appears to be working:~~

Testing of standard baud rates shows it caps out at 3,000,000 baud:

    Running `usd-runner target/armv7a-none-eabi/debug/examples/hello`
    Hello, world!
    (device has reset)

~~I didn't experiment with making it faster than that as the other standard baud rates higher than that do not divide evenly into 80MHz (and doing non-integer division with UBMR/UBIR was breaking my brain), but otherwise this is at least a PoC that the runner works on macOS at a lower baud rate.~~